### PR TITLE
Zmena adresarovej struktury pre submit

### DIFF
--- a/trojsten/submit/helpers.py
+++ b/trojsten/submit/helpers.py
@@ -93,15 +93,15 @@ def process_submit_raw(f, contest_id, task_id, language, user_id):
     timestamp = int(time())
     submit_id = "%d-%05d" % (timestamp, random.randint(0, 99999))
 
-    # Determine local directory to store RAW file into
-    path = get_path_raw(contest_id, task_id, user_id)
-
     # Prepare submit parameters (not entirely sure about this yet).
     user_id = "%s-%d" % (contest_id, user_id)
     task_id = "%s-%d" % (contest_id, task_id)
     original_name = f.name
     correct_filename = task_id + language
     data = f.read()
+    
+    # Determine local directory to store RAW file into
+    path = get_path_raw(contest_id, task_id, user_id)
 
     # Prepare RAW from submit parameters
     raw = "%s\n%s\n%s\n%s\n%s\n%s\n%s" % (


### PR DESCRIPTION
Nastavena adresarova struktura tak aby bola kompatibilna so starym web-om... 

SUBMIT_PATH sa nastavi na /var/www/betakspweb
/var/www/betakspweb/submits bude symbolic link na /var/www/eRiesenie/submits
a vo /var/www/eRiesenie/submits su adresare s KSP-<userid> a v nich su adresare s KSP-<task_id>
