### PR TITLE
Fixed HTML injection vulnerability in messages

### DIFF
--- a/trojsten/settings/common.py
+++ b/trojsten/settings/common.py
@@ -259,6 +259,12 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     "trojsten.context_processors.current_site",
 )
 
+# Override message tags for bootstrap 3 compatibility.
+from django.contrib.messages import constants as messages
+MESSAGE_TAGS = {
+    messages.ERROR: 'danger',
+}
+
 # The list of authentication backends we want to allow.
 AUTHENTICATION_BACKENDS = (
     #'social.backends.facebook.FacebookOAuth2',

--- a/trojsten/templates/trojsten/layout/main.html
+++ b/trojsten/templates/trojsten/layout/main.html
@@ -12,13 +12,10 @@
         {% if messages %}
         <!-- Messages for this instance -->
         {% for message in messages %}
-            {% if message.tags == 'error' %}
-            <div class="alert alert-danger" role="alert">
-            {% else %}
+            {# TODO: after bump to Django>=1.7, use level_tag here #}
             <div class="alert alert-{{ message.tags }}" role="alert">
-            {% endif %}
                 <a class="close" data-dismiss="alert" href="#">&times;</a>
-                {{ message|safe }}
+                {{ message }}
             </div>
         {% endfor %}
         {% endif %}


### PR DESCRIPTION
Cleaned up related code a little in the process.

Closes #270.

Funny thing, ukázalo sa, že vlastne nič z toho zložitého, čo som plánoval, nakoniec nebolo treba, lebo minimálne od 1.6 `d.c.messages` zvláda automaticky handlovať safe stringy.

Niekto to, prosím, vyskúšajte, nemám u seba rozbehaný testovač, ani mock, takže som nevedel vyskúšať, či sa skutočne tie konkrétne message renderujú správne.
