### PR TITLE
fix tester does not know where to write protocol for other competitions

### DIFF
--- a/trojsten/settings/common.py
+++ b/trojsten/settings/common.py
@@ -26,6 +26,7 @@ TASK_STATEMENTS_PATH = ''
 TASK_STATEMENTS_REPO_PATH = ''
 TESTER_URL = 'experiment'
 TESTER_PORT = 12347
+TESTER_WEB_IDENTIFIER = 'KSP'
 
 ADMINS = (
     # ('Your Name', 'your_email@example.com'),

--- a/trojsten/submit/helpers.py
+++ b/trojsten/submit/helpers.py
@@ -10,7 +10,6 @@ from decimal import Decimal
 
 RESPONSE_ERROR = 'CERR'
 RESPONSE_OK = 'OK'
-TESTER_WEB_IDENTIFIER = 'KSP'
 
 
 def write_file(text, binary, where):
@@ -120,7 +119,7 @@ def process_submit_raw(f, contest_id, task_id, language, user_id):
 
     # Prepare RAW from submit parameters
     raw = "%s\n%s\n%s\n%s\n%s\n%s\n" % (
-        TESTER_WEB_IDENTIFIER,
+        settings.TESTER_WEB_IDENTIFIER,
         submit_id,
         user_id,
         correct_filename,


### PR DESCRIPTION
Pre ine sutaze ako KSP (napr. KSP-T je samostatna sutaz) sa v prvom riadku RAW-u posielal identifikator sutaze, to je chyba, ma sa tam posielat identifikator web-u, podla tohto riadku testovac zistuje kam ma protokol zapisat.. 
#293
