### PR TITLE
removed now unnecessary admin import and auto discover

### DIFF
--- a/trojsten/regal/tasks/management/commands/revalidate_task.py
+++ b/trojsten/regal/tasks/management/commands/revalidate_task.py
@@ -1,14 +1,12 @@
 from django.core.management.base import BaseCommand, CommandError
 
-from django.contrib import admin
-admin.autodiscover()
-
 from trojsten.regal.tasks.models import Task, Submit
 from trojsten.submit.helpers import update_submit
 
 
 class Command(BaseCommand):
     args = '<task_id task_id ...>'
+
     def handle(self, *args, **options):
         for task_id in args:
             try:
@@ -18,5 +16,5 @@ class Command(BaseCommand):
 
             for submit in Submit.objects.filter(task=task).all():
                 update_submit(submit)
-           
+
             self.stdout.write('Task "%s" successfully revalidated' % task_id)


### PR DESCRIPTION
- lines were needed because of using get_user_model function in model definitions which caused error when this lines wasn't here
