### PR TITLE
try to fix encoding related errors in reviews

### DIFF
--- a/trojsten/reviews/forms.py
+++ b/trojsten/reviews/forms.py
@@ -164,6 +164,7 @@ class ZipForm(forms.Form):
         cleaned_data = super(ZipForm, self).clean()
         self.name = cleaned_data['filename']
         if sys.version_info[0] == 3:
+            # FIXME: remove this check when we stop supporting python2.7
             cleaned_data['filename'] = unquote(cleaned_data['filename'])
         else:
             cleaned_data['filename'] = unquote(cleaned_data['filename'].encode('ascii'))

--- a/trojsten/reviews/tests.py
+++ b/trojsten/reviews/tests.py
@@ -21,6 +21,7 @@ class ReviewZipFormTests(TestCase):
         self.valid_files_win1250 = set([self.test_str_win1250])
         self.valid_files_utf8 = set([self.test_str_utf8])
         if sys.version_info[0] == 3:
+            # FIXME: remove this check when we stop supporting python2.7
             self.valid_files_win1250 = set([unquote(quote(self.test_str_win1250))])
             self.valid_files_utf8 = set([self.test_str_utf8.decode('utf8')])
         self.user = User(pk=47)


### PR DESCRIPTION
- nefungovali komentare s diakritikou v windows-1250(asi?) kodovani..
  - fixed by: skusit komentar dekodovat z utf8, ak nie tak z cp1250, ak nie tak unidecode (zahodi diakritiku) == pri akomkolvek kodovani sa snad zjavi rozumna odpoved v policku komentar
- rubalo sa to aj ked filename obsahoval nejake znaky s diakritikou..
  - fixed by: zakoduje/dekoduje filename cez urllib.quote, to by malo fungovat spravne obojsmerne pri akomkolvek kodovani filenamov v zip-e 
