### PR TITLE
integration of django tips

### DIFF
--- a/requirements.devel.txt
+++ b/requirements.devel.txt
@@ -39,8 +39,10 @@ django-sortedm2m==1.3.0
 django-tag-parser==2.1
 django-taggit==0.19.1     # via django-trojsten-news
 django-threadedcomments==1.0.1
+django-tips==0.2.0
 django-trojsten-news==0.1.3
-Django==1.9.7             # via django-bootstrap-form, django-classy-tags, django-contrib-comments, django-debug-toolbar, django-mptt, django-nyt, django-oauth-toolkit, django-sendfile, django-trojsten-news, ksp-login, wiki
+Django==1.9.7             # via django-bootstrap-form, django-classy-tags, django-contrib-comments, django-debug-toolbar, django-mptt, django-nyt, django-oauth-toolkit, django-sendfile, django-tips, django-trojsten-news, ksp-login, wiki
+djangorestframework==3.3.3  # via django-tips
 ecdsa==0.13
 Fabric==1.11.1
 fake-factory==0.5.7
@@ -49,7 +51,7 @@ importlib==1.0.3
 ipaddress==1.0.16         # via fake-factory
 kombu==3.0.35             # via celery
 ksp-login==0.4.2
-Markdown==2.6.6           # via django-trojsten-news, pymdown-extensions, wiki
+Markdown==2.6.6           # via django-tips, django-trojsten-news, pymdown-extensions, wiki
 oauthlib==1.0.3           # via django-oauth-toolkit, python-social-auth, requests-oauthlib
 paramiko==1.17.0          # via fabric
 Pillow==3.2.0             # via wiki

--- a/requirements.in
+++ b/requirements.in
@@ -16,6 +16,7 @@ django-oauth-toolkit
 django-sekizai
 django-sendfile
 django-sortedm2m
+django-tips
 django-trojsten-news
 django-threadedcomments
 Django<1.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,8 +35,10 @@ django-sortedm2m==1.3.0
 django-tag-parser==2.1
 django-taggit==0.19.1     # via django-trojsten-news
 django-threadedcomments==1.0.1
+django-tips==0.2.0
 django-trojsten-news==0.1.3
-Django==1.9.7             # via django-bootstrap-form, django-classy-tags, django-contrib-comments, django-mptt, django-nyt, django-oauth-toolkit, django-sendfile, django-trojsten-news, ksp-login, wiki
+Django==1.9.7             # via django-bootstrap-form, django-classy-tags, django-contrib-comments, django-mptt, django-nyt, django-oauth-toolkit, django-sendfile, django-tips, django-trojsten-news, ksp-login, wiki
+djangorestframework==3.3.3  # via django-tips
 ecdsa==0.13
 fake-factory==0.5.7
 first==2.0.1
@@ -44,7 +46,7 @@ importlib==1.0.3
 ipaddress==1.0.16         # via fake-factory
 kombu==3.0.35             # via celery
 ksp-login==0.4.2
-Markdown==2.6.6           # via django-trojsten-news, pymdown-extensions, wiki
+Markdown==2.6.6           # via django-tips, django-trojsten-news, pymdown-extensions, wiki
 oauthlib==1.0.3           # via django-oauth-toolkit, python-social-auth, requests-oauthlib
 Pillow==3.2.0             # via wiki
 psycopg2==2.6.1

--- a/trojsten/settings/common.py
+++ b/trojsten/settings/common.py
@@ -211,6 +211,7 @@ INSTALLED_APPS = (
 
     # Keep this under trojsten to let trojsten override templates.
     'news',
+    'tips',
     'django.contrib.admin',
     'social.apps.django_app.default',
     'ksp_login',

--- a/trojsten/special/plugin_prask_2_4_1/templates/plugin_prask_2_4_1/task_view.html
+++ b/trojsten/special/plugin_prask_2_4_1/templates/plugin_prask_2_4_1/task_view.html
@@ -32,9 +32,6 @@
     </form>
 
     {% addtoblock "js" %}
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.0.1/react.min.js" type="text/javascript"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.0.1/react-dom.min.js" type="text/javascript"></script>
-        <script src="{% static "js/csrf_token.js" %}"></script>
         <script src="{% static "plugin_prask_2_4_1/js/lib/main.js" %}" type="text/javascript"></script>
     {% endaddtoblock %}
 

--- a/trojsten/templates/trojsten/layout/base.html
+++ b/trojsten/templates/trojsten/layout/base.html
@@ -32,7 +32,9 @@
       <![endif]-->
       <!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
       <script src="{% static "js/ie10-viewport-bug-workaround.js" %}"></script>
-
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.0.1/react.min.js" type="text/javascript"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/react/15.0.1/react-dom.min.js" type="text/javascript"></script>
+      <script src="{% static "js/csrf_token.js" %}"></script>
       <script src="{% static "js/menu.js" %}" type="text/javascript"></script>
       <script src="{% static "js/submit-ajax.js" %}" type="text/javascript"></script>
       <script src="{% static "js/bootstrap-load-plugins.js" %}" type="text/javascript"></script>

--- a/trojsten/templates/trojsten/layout/main.html
+++ b/trojsten/templates/trojsten/layout/main.html
@@ -7,9 +7,9 @@
   <div class="row">
     <nav class="col-md-3 col-sm-3 col-xs-6 offcanvas-xs nav-menu">{% navigation %}</nav>
     <div class="col-md-9 col-sm-9 col-xs-12 main-content">
-    <div class="page-header">
-        {% block page_header %}{% endblock %}
-    </div>
+        <div class="page-header">
+            {% block page_header %}{% endblock %}
+        </div>
         {% if messages %}
         <!-- Messages for this instance -->
         {% for message in messages %}
@@ -21,7 +21,12 @@
             {% endwith %}
         {% endfor %}
         {% endif %}
-    {% block page_content %}{% endblock %}
+
+        {% if user.is_authenticated and user.is_staff %}
+        {% include "tips/tips.html" %}
+        {% endif %}
+
+        {% block page_content %}{% endblock %}
     </div>
   </div>
 </div>

--- a/trojsten/urls/default.py
+++ b/trojsten/urls/default.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 import news.urls
 from django_nyt.urls import get_pattern as get_notify_pattern
 from wiki.urls import get_pattern as get_wiki_pattern
+import tips.urls
 
 import trojsten.contests.views
 import trojsten.contests.urls
@@ -18,6 +19,7 @@ urlpatterns += [
     url(r'^odovzdavanie/', include(trojsten.submit.urls)),
     url(r'^vysledky/', include(trojsten.results.urls)),
     url(r'^novinky/', include(news.urls)),
+    url(r'^api/tips/', include(tips.urls, namespace='tips')),
     url(r'^ulohy/', include(trojsten.contests.urls)),
     url(r'^archiv/$', trojsten.contests.views.archive, {'path': '/archiv'},
         name='archive'),


### PR DESCRIPTION
Jednoduche 'tipy dna/tutorial' pre veducich.
Zdrojak: https://github.com/trojsten/django-tips

Da sa lahko pouzit na zaskolovanie veducich do novych funkcii webu.

Closes #783 

Screenshot:
![novinky korespondencny seminar z programovania](https://cloud.githubusercontent.com/assets/1177655/15971717/f23e90ce-2f3a-11e6-9fde-0c5b446d547b.png)
