### PR TITLE
Object Level Permissions DEMO

### DIFF
--- a/trojsten/contests/admin.py
+++ b/trojsten/contests/admin.py
@@ -1,18 +1,22 @@
 # -*- coding: utf-8 -*-
-
-from __future__ import unicode_literals
+from __future__ import absolute_import, unicode_literals
 
 from django.contrib import admin
 from django.utils.encoding import force_text
 from easy_select2 import select2_modelform
-
+from trojsten.contests.forms import TaskValidationForm
 from trojsten.contests.models import Category, Competition, Round, Series, Task
 from trojsten.reviews.urls import task_review_urls
-from trojsten.contests.forms import TaskValidationForm
 from trojsten.utils.utils import attribute_format, get_related
+from trojsten.utils.permissions import ObjectPermissionsModelAdmin
+
+from .rules import is_competition_organizer_filter
 
 
-class CompetitionAdmin(admin.ModelAdmin):
+class CompetitionAdmin(ObjectPermissionsModelAdmin):
+    def get_filter_query(self, request):
+        return is_competition_organizer_filter(request.user)
+
     form = select2_modelform(Competition)
     list_display = ('name', 'organizers_group', 'get_sites')
 

--- a/trojsten/contests/rules.py
+++ b/trojsten/contests/rules.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import
+
+from django.db.models import Q
+
+from trojsten.utils.permissions import set_permissions_from_filter
+
+
+def is_competition_organizer_filter(user):
+    if user.is_superuser:
+        return None
+    return Q(
+        organizers_group__in=user.groups.all(),
+    )
+
+
+set_permissions_from_filter(
+    'contests', 'competition', is_competition_organizer_filter,
+)

--- a/trojsten/settings/common.py
+++ b/trojsten/settings/common.py
@@ -232,7 +232,7 @@ INSTALLED_APPS = (
     'oauth2_provider',
     'corsheaders',
     'rest_framework',
-    'rules',
+    'rules.apps.AutodiscoverRulesConfig',
 
     # django-wiki and its dependencies
     'django.contrib.humanize',

--- a/trojsten/settings/common.py
+++ b/trojsten/settings/common.py
@@ -4,12 +4,11 @@ import json
 import os
 import sys
 
+import trojsten
+import trojsten.special.installed_apps
 from django.contrib.messages import constants as messages
 from django.http import UnreadablePostError
 from django.utils.translation import ugettext_lazy as _
-
-import trojsten
-import trojsten.special.installed_apps
 
 from . import site_config
 
@@ -233,6 +232,7 @@ INSTALLED_APPS = (
     'oauth2_provider',
     'corsheaders',
     'rest_framework',
+    'rules',
 
     # django-wiki and its dependencies
     'django.contrib.humanize',
@@ -325,6 +325,7 @@ LOGIN_PROVIDERS = (
 )
 
 AUTHENTICATION_BACKENDS = LOGIN_PROVIDERS + (
+    'rules.permissions.ObjectPermissionBackend',
     'django.contrib.auth.backends.ModelBackend',
 )
 

--- a/trojsten/utils/permissions.py
+++ b/trojsten/utils/permissions.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+import rules
+from django.core.exceptions import ObjectDoesNotExist
+from rules.contrib.admin import \
+    ObjectPermissionsModelAdmin as RulesObjectPermissionsModelAdmin
+
+
+def get_predicate_from_filter(db_query):
+    @rules.predicate
+    def db_filter_predicate(user, obj):
+        if obj is None:
+            return None
+        try:
+            obj.__class__.objects.filter(db_query(user)).get(pk=obj.pk)
+            return True
+        except ObjectDoesNotExist:
+            return False
+    return db_filter_predicate
+
+
+def set_permissions_from_filter(app, model, filter_query, change=True, delete=True):
+    if change:
+        rules.add_perm(
+            '{app}.change_{model}'.format(
+                app=app, model=model,
+            ), get_predicate_from_filter(
+                filter_query
+            )
+        )
+    if delete:
+        rules.add_perm(
+            '{app}.delete_{model}'.format(
+                app=app, model=model,
+            ), get_predicate_from_filter(
+                filter_query
+            )
+        )
+
+
+class ObjectPermissionsModelAdmin(RulesObjectPermissionsModelAdmin):
+    def get_filter_query(self, request):
+        return None
+
+    def get_queryset(self, request):
+        fq = self.get_filter_query(request)
+        qs = super(RulesObjectPermissionsModelAdmin, self).get_queryset(request)
+        if fq is not None:
+            qs = qs.filter(fq)
+        return qs


### PR DESCRIPTION
related #53 

Demo systemu permissions, pre jednoduchost demonstrovane na modeli Competitions.
Toto sa este nebude mergovat, az ked sa rozhodneme ze to ide spravnym smerom.

Prosim komentare o tom co si kto o tom mysli.
## Co to dokaze
- Je tam Django admin, ktory podporuje filtrovanie a permissions.
- Volanie has_permission na modeli vrati hodnoty podla 3-hodnotovych pravidiel (allow, deny, skip), vieme pripadne pridat aj ine permissions ako change a delete
- Konverzia filtra na pravidlo
## Poznamky
- v adminovi chceme iny queryset filter ako vo web rozhrani (priklad: uzivatel chce vidiet vsetky ulohy vsetkych seminarov, veduci v adminovi len ulohy svojho seminara)
- v adminovi neni vidiet na ktore objekty ma user opravnenia (ak nema change pravo, ale objekt je viditelny, vyzera rovnako ako tie na ktore ma permission, akurat po kliknuti dostane 403)
## Vyhody
- podporuje to nativna django permissions, ktore sa daju vydefinovat priamo z querysetu
- permission sa daju definovat na 1 mieste (rules.py)
## Nevyhody
- je to pomerne tazkopadne a zlozite
