### PR TITLE
don't redirect to news after submitting a contact form

### DIFF
--- a/trojsten/views.py
+++ b/trojsten/views.py
@@ -10,7 +10,7 @@ from wiki.views import article
 
 def contact_form_sent_redirect(request):
     messages.success(request, 'Vaša správa bola odoslaná. Ďakujeme za spätnú väzbu.')
-    return redirect('/')
+    return redirect('contact_form')
 
 
 def home_redirect(request):


### PR DESCRIPTION
fixes #848 
Odteraz by to uz nemalo presmerovavat do noviniek, ale ostat na contact forme.

Snad to je ok.
