### PR TITLE
Upgrade Django to latest security release

### DIFF
--- a/requirements.devel.txt
+++ b/requirements.devel.txt
@@ -10,77 +10,77 @@ amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
 bumpversion==0.5.3
-celery==3.1.23
-cffi==1.7.0               # via cryptography
+celery==3.1.24
+cffi==1.8.3               # via cryptography
 click==6.6                # via pip-tools
 coverage==4.2
-cryptography==1.4         # via pyopenssl
+cryptography==1.5.2       # via pyopenssl
 diff-match-patch==20121119  # via django-import-export
 django-autoslug==1.9.3    # via django-trojsten-news
 django-bootstrap-form==3.2.1
 django-braces==1.9.0      # via django-oauth-toolkit
 django-bulk-update==1.1.10
-django-classy-tags==0.7.2
+django-classy-tags==0.8.0
 django-contact-form==1.2
-django-contrib-comments==1.7.2
-django-cors-headers==1.1.0
-django-crispy-forms==1.6.0
-django-debug-toolbar==1.5
+django-contrib-comments==1.7.3
+django-cors-headers==1.2.2
+django-crispy-forms==1.6.1
+django-debug-toolbar==1.6
 django-dotenv==1.4.1
 django-easy-select2==1.3.3
 django-favicon==0.1.2
 django-haystack==2.5.0
-django-import-export==0.4.5
+django-import-export==0.5.1
 django-mathfilters==0.4.0
-django-mptt==0.8.5        # via wiki
+django-mptt==0.8.6        # via wiki
 django-nyt==0.9.9         # via wiki
 django-oauth-toolkit==0.10.0
-django-sekizai==0.9.0
-django-sendfile==0.3.10
+django-sekizai==0.10.0
+django-sendfile==0.3.11
 django-sortedm2m==1.3.2
-django-tag-parser==2.1
-django-taggit==0.20.2     # via django-trojsten-news
+django-tag-parser==3.0
+django-taggit==0.21.3     # via django-trojsten-news
 django-threadedcomments==1.0.1
 django-tips==0.4.0
 django-trojsten-news==0.1.3
-Django==1.9.9             # via django-bootstrap-form, django-classy-tags, django-contrib-comments, django-debug-toolbar, django-haystack, django-nyt, django-oauth-toolkit, django-sendfile, django-tips, django-trojsten-news, ksp-login, wiki
-djangorestframework==3.4.4
+Django==1.9.10            # via django-bootstrap-form, django-classy-tags, django-contrib-comments, django-debug-toolbar, django-haystack, django-nyt, django-oauth-toolkit, django-sendfile, django-tips, django-trojsten-news, ksp-login, wiki
+djangorestframework==3.5.1
 ecdsa==0.13
-elasticsearch==2.4.0
+elasticsearch==5.0.0
 enum34==1.1.6             # via cryptography
 Fabric==1.12.0
-fake-factory==0.6.0
+fake-factory==0.7.2
 first==2.0.1
 idna==2.1                 # via cryptography
-importlib==1.0.3
-ipaddress==1.0.16         # via cryptography, fake-factory
-kombu==3.0.35             # via celery
+importlib==1.0.4
+ipaddress==1.0.17         # via cryptography, fake-factory
+kombu==3.0.37             # via celery
 ksp-login==0.4.2
-Markdown==2.6.6           # via django-tips, django-trojsten-news, pymdown-extensions, wiki
+Markdown==2.6.7           # via django-tips, django-trojsten-news, pymdown-extensions, wiki
 ndg-httpsclient==0.4.2
 oauthlib==1.0.3           # via django-oauth-toolkit, python-social-auth, requests-oauthlib
 paramiko==1.17.2          # via fabric
-Pillow==3.3.0             # via wiki
+Pillow==3.4.2             # via wiki
 pip-tools==1.7.0
 psycopg2==2.6.2
 pyasn1==0.1.9             # via cryptography
-pycparser==2.14           # via cffi
+pycparser==2.16           # via cffi
 pycrypto==2.6.1
 PyJWT==1.4.2              # via python-social-auth
 pymdown-extensions==1.1
-PyOpenSSL==16.0.0         # via ndg-httpsclient
+PyOpenSSL==16.2.0         # via ndg-httpsclient
 python-dateutil==2.5.3    # via fake-factory
 python-openid==2.2.5      # via python-social-auth
 python-social-auth==0.2.21
-pytz==2016.6.1
-requests-oauthlib==0.6.2  # via python-social-auth
-requests==2.11.0          # via python-social-auth, requests-oauthlib
+pytz==2016.7
+requests-oauthlib==0.7.0  # via python-social-auth
+requests==2.11.1          # via python-social-auth, requests-oauthlib
 six==1.10.0               # via cryptography, django-nyt, django-oauth-toolkit, fake-factory, pip-tools, pyopenssl, python-dateutil, python-social-auth, wiki
 sorl-thumbnail==12.3      # via wiki
 sqlparse==0.2.1
 tablib==0.11.2            # via django-import-export
 Unidecode==0.4.19
-urllib3==1.16             # via elasticsearch
+urllib3==1.18             # via elasticsearch
 wiki==0.1.2
 
 # The following packages are commented out because they are

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,70 +9,70 @@ akismet==0.2.0
 amqp==1.4.9               # via kombu
 anyjson==0.3.3            # via kombu
 billiard==3.3.0.23        # via celery
-celery==3.1.23
-cffi==1.7.0               # via cryptography
-cryptography==1.4         # via pyopenssl
+celery==3.1.24
+cffi==1.8.3               # via cryptography
+cryptography==1.5.2       # via pyopenssl
 diff-match-patch==20121119  # via django-import-export
 django-autoslug==1.9.3    # via django-trojsten-news
 django-bootstrap-form==3.2.1
 django-braces==1.9.0      # via django-oauth-toolkit
 django-bulk-update==1.1.10
-django-classy-tags==0.7.2
+django-classy-tags==0.8.0
 django-contact-form==1.2
-django-contrib-comments==1.7.2
-django-cors-headers==1.1.0
-django-crispy-forms==1.6.0
+django-contrib-comments==1.7.3
+django-cors-headers==1.2.2
+django-crispy-forms==1.6.1
 django-dotenv==1.4.1
 django-easy-select2==1.3.3
 django-favicon==0.1.2
 django-haystack==2.5.0
-django-import-export==0.4.5
+django-import-export==0.5.1
 django-mathfilters==0.4.0
-django-mptt==0.8.5        # via wiki
+django-mptt==0.8.6        # via wiki
 django-nyt==0.9.9         # via wiki
 django-oauth-toolkit==0.10.0
-django-sekizai==0.9.0
-django-sendfile==0.3.10
+django-sekizai==0.10.0
+django-sendfile==0.3.11
 django-sortedm2m==1.3.2
-django-tag-parser==2.1
-django-taggit==0.20.2     # via django-trojsten-news
+django-tag-parser==3.0
+django-taggit==0.21.3     # via django-trojsten-news
 django-threadedcomments==1.0.1
 django-tips==0.4.0
 django-trojsten-news==0.1.3
-Django==1.9.9             # via django-bootstrap-form, django-classy-tags, django-contrib-comments, django-haystack, django-nyt, django-oauth-toolkit, django-sendfile, django-tips, django-trojsten-news, ksp-login, wiki
-djangorestframework==3.4.4
+Django==1.9.10            # via django-bootstrap-form, django-classy-tags, django-contrib-comments, django-haystack, django-nyt, django-oauth-toolkit, django-sendfile, django-tips, django-trojsten-news, ksp-login, wiki
+djangorestframework==3.5.1
 ecdsa==0.13
-elasticsearch==2.4.0
+elasticsearch==5.0.0
 enum34==1.1.6             # via cryptography
-fake-factory==0.6.0
+fake-factory==0.7.2
 first==2.0.1
 idna==2.1                 # via cryptography
-importlib==1.0.3
-ipaddress==1.0.16         # via cryptography, fake-factory
-kombu==3.0.35             # via celery
+importlib==1.0.4
+ipaddress==1.0.17         # via cryptography, fake-factory
+kombu==3.0.37             # via celery
 ksp-login==0.4.2
-Markdown==2.6.6           # via django-tips, django-trojsten-news, pymdown-extensions, wiki
+Markdown==2.6.7           # via django-tips, django-trojsten-news, pymdown-extensions, wiki
 ndg-httpsclient==0.4.2
 oauthlib==1.0.3           # via django-oauth-toolkit, python-social-auth, requests-oauthlib
-Pillow==3.3.0             # via wiki
+Pillow==3.4.2             # via wiki
 psycopg2==2.6.2
 pyasn1==0.1.9             # via cryptography
-pycparser==2.14           # via cffi
+pycparser==2.16           # via cffi
 pycrypto==2.6.1
 PyJWT==1.4.2              # via python-social-auth
 pymdown-extensions==1.1
-PyOpenSSL==16.0.0         # via ndg-httpsclient
+PyOpenSSL==16.2.0         # via ndg-httpsclient
 python-dateutil==2.5.3    # via fake-factory
 python-openid==2.2.5      # via python-social-auth
 python-social-auth==0.2.21
-pytz==2016.6.1
-requests-oauthlib==0.6.2  # via python-social-auth
-requests==2.11.0          # via python-social-auth, requests-oauthlib
+pytz==2016.7
+requests-oauthlib==0.7.0  # via python-social-auth
+requests==2.11.1          # via python-social-auth, requests-oauthlib
 six==1.10.0               # via cryptography, django-nyt, django-oauth-toolkit, fake-factory, pyopenssl, python-dateutil, python-social-auth, wiki
 sorl-thumbnail==12.3      # via wiki
 tablib==0.11.2            # via django-import-export
 Unidecode==0.4.19
-urllib3==1.16             # via elasticsearch
+urllib3==1.18             # via elasticsearch
 wiki==0.1.2
 
 # The following packages are commented out because they are


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.10/releases/1.9.10/ bol tam daky CSRF umoznujuci bug v cookie parsing-u.., (aj ked pochybujem, ze by to na trojstenweb-e niekto mal dovod zneuzivat :D )
