### PR TITLE
update build_requirements.sh for python3

### DIFF
--- a/build_requirements.sh
+++ b/build_requirements.sh
@@ -1,3 +1,12 @@
 #!/bin/bash
-pip-compile requirements.in requirements2.in -o requirements.txt
-pip-compile requirements.in requirements2.in requirements.devel.in -o requirements.devel.txt
+
+version=`python -c "import sys; print(sys.version)" | head -n1 | cut -c1`
+if [ $version = 3 ]
+then
+    SOURCES="requirements.in"
+else
+    SOURCES="requirements.in requirements2.in"
+fi
+
+pip-compile $SOURCES -o requirements.txt
+pip-compile $SOURCES requirements.devel.in -o requirements.devel.txt


### PR DESCRIPTION
Na novych servroch rozbehavame python3.5, build_requirements.sh vzdy generuje requirement-y pre 2-ku.. toz upravil som nech to bezi aj na 3-ke aj na 2-ke.. (na archivovi ani u mna to aj tak nechce bezat, ale na novych servroch bezi takze to je asi podstatne)
