### PR TITLE
Keep using older celery (for now)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-celery
+celery<4.0.0
 django-bootstrap-form
 django-bulk-update
 django-classy-tags


### PR DESCRIPTION
Vyslo nove celery (4.0), ktore ma zopar zmien, ktore sa nas mozu tykat.., najvyraznejsia z tychto zmien je, ze zo zakladneho balika vyhodili podporu django ORM ako result backend-u (co sposobi fail testov v PR #926 )

Vzhladom na to, ze momentalne AFAIK celery pouzivame iba ako testovac pre jednu zo specialnych uloh (zergbot), namiesto upravovania konfigurakov / rozbehavania novej verzie aby to fungovalo by som zatial iba freezol verziu, nech nam vsetko funguje tak ako doteraz.. 