### PR TITLE
Refactor fabfile.py (+ new server architecture compatibility)

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -23,6 +23,7 @@ env.roledefs = {
         'use_sudo': False,
         'server_configuration': 'trojsten/*.wsgi',
         'local': False,
+        'build_requirements': False
     },
     'beta': {
         'hosts': ['inteligent.trojsten.sk:22100'],
@@ -34,6 +35,7 @@ env.roledefs = {
         'shell': '/usr/local/bin/bash -l -c',
         'server_configuration': '/usr/local/www/trojstenweb/*.yaml',
         'local': False,
+        'build_requirements': True
     },
     'local': {
         'user': os.environ.get('USER'),
@@ -43,6 +45,7 @@ env.roledefs = {
         'db_name': 'trojsten',
         'use_sudo': False,
         'local': True,
+        'build_requirements': False
     }
 }
 
@@ -73,6 +76,9 @@ def prod():
 
 def pull():
     with cd(env.project_path):
+        if env.build_requirements:
+            run('git reset HEAD requirements*')
+            run('git checkout -- requirements*')
         run('git pull')
 
 
@@ -91,6 +97,8 @@ def load_fixtures():
 def install_requirements():
     with cd(env.project_path):
         with prefix('workon %s' % env.virtualenv_name):
+            if env.build_requirements:
+                run('bash build_requirements.sh')
             run('pip install -r requirements.txt --exists-action w')
             if env.local:
                 run('pip install -r requirements.devel.txt')


### PR DESCRIPTION
- Uses `fabric.api.env` instead of global variables 
- Should be ready to use fabric roles when fabric starts supporting them for more than just setting host and user
- Adds new configuration options for compatibility with new server architecture
  - everyone logs onto the new server with his own username and then uses sudo to run fabric commands
  - Enabled env.use_ssh_config to be able to load env.user from native ssh configuration file (~/.ssh/config)
  - Added server_configuration option to set the files that should be touched to restart WSGI server

(Note: beta.ksp.sk is now running on trojstenweb@inteligent.trojsten.sk:22100, this configuration file reflects that.., this instance will be used for running production sites and new beta instance will be created when we switch to running production sites on new servers.., fabfile will need to be updated when that happens)

closes #927 