### PR TITLE
Fix testing result being displayed as None

### DIFF
--- a/trojsten/submit/views.py
+++ b/trojsten/submit/views.py
@@ -108,6 +108,7 @@ def view_protocol(request, submit_id):
             protocol_path, submit.submit_type == constants.SUBMIT_TYPE_TESTABLE_ZIP
         )
         template_data['submit'] = submit
+        template_data['submit_verbose_response'] = constants.SUBMIT_VERBOSE_RESPONSE
         return render(
             request, 'trojsten/submit/protocol.html', template_data
         )


### PR DESCRIPTION
- Happened only when protocol was loaded through AJAX, because the AJAX view wasn't properly updated when we moved the verbose tester responses to constants.py
- maybe we should consider not displaying it like this, alternative usage may be for example creating a specific templatetag |verbose_tester_response, or adding the SUBMIT_VERBOSE_RESPONSE constant to global template context?

fixes #894