### PR TITLE
Fix duplication of progressbar alert

### DIFF
--- a/trojsten/contests/templates/trojsten/contests/parts/progress.html
+++ b/trojsten/contests/templates/trojsten/contests/parts/progress.html
@@ -1,25 +1,26 @@
 {% load statements_parts sekizai_tags staticfiles i18n %}
 {% if remaining.days >= 0 %}
 {% addtoblock "js" %}
-    <script type="text/javascript" src="{% static "js/roundprogressbar.js" %}">
+    <script type="text/javascript" src="{% static 'js/roundprogressbar.js' %}">
     </script>
 {% endaddtoblock %}
-<div class="row roundprogressbar" id="progressbar-{{ round.id }}" data-id="{{ round.id }}" data-precision="{{ remaining|progress_time_precision }}" data-isresults={{ results }}>
-  {% if round.second_phase_running %}
-    <div class="col-md-5"><em>{% trans "Submit programs until" %}: {{ end }}</em></div>
-  {% else %}
-    <div class="col-md-5"><em>{% trans "End of the round" %}: {{ end }}</em></div>
-  {% endif %}
-  <div class="col-md-7">
-    <div class="progress">
-      <div class="progress-bar {{ progressbar_class }}" role="progressbar"
-           aria-valuenow="{{ elapsed.days }}" aria-valuemin="0"
-           aria-valuemax="{{ full.days }}" style="width: {{ percent }}%;">
-        {{ remaining|progress_time }}
+<div class="roundprogressbar" id="progressbar-{{ round.id }}" data-id="{{ round.id }}" data-precision="{{ remaining|progress_time_precision }}" data-isresults={{ results }}>
+  <div class="row">
+    {% if round.second_phase_running %}
+      <div class="col-md-5"><em>{% trans "Submit programs until" %}: {{ end }}</em></div>
+    {% else %}
+      <div class="col-md-5"><em>{% trans "End of the round" %}: {{ end }}</em></div>
+    {% endif %}
+    <div class="col-md-7">
+      <div class="progress">
+        <div class="progress-bar {{ progressbar_class }}" role="progressbar"
+             aria-valuenow="{{ elapsed.days }}" aria-valuemin="0"
+             aria-valuemax="{{ full.days }}" style="width: {{ percent }}%;">
+          {{ remaining|progress_time }}
+        </div>
       </div>
     </div>
   </div>
-</div>
   {% if round.second_phase_running %}
     <div class="alert alert-info">
       {% blocktrans %}
@@ -28,6 +29,7 @@
       {% endblocktrans %}
     </div>
   {% endif %}
+</div>
 {% else %}
   {% if results %}
     <div class="alert alert-warning">{% trans "The results are preliminary." %}</div>


### PR DESCRIPTION
Closes #1025 

Javascript co updatuje progressbar zoberie cely div `.progressbar` a nahradi ho celym templatom.
Fixol som to tak, ze hlasku o doprogramovani som dal do toho divu.
