### PR TITLE
Fix admin list view for task

### DIFF
--- a/trojsten/contests/admin.py
+++ b/trojsten/contests/admin.py
@@ -85,7 +85,7 @@ class TaskByYearSubFilter(admin.SimpleListFilter):
                     'round__semester__competition__id__exact'
                 ]
             )
-        tasks = tasks.select_related('round__semester__year')
+        tasks = tasks.select_related('round__semester')
         tasks = tasks.distinct('round__semester__year').order_by(
             '-round__semester__year')
         years = (x.round.semester.year for x in tasks.all())


### PR DESCRIPTION
Asi s novou verziou Djanga zacalo vadit, ze v `select_related` sme chceli tahat field (year) a nie model.

Vygrepoval som este aj dalsie pouzitia `select_related` a `prefetch_related` a myslim, ze uz vsade inde tahame modely, tak ako sa to ma robit.
