### PR TITLE
Compute KMS coefficient and minor changes in events models

### DIFF
--- a/trojsten/events/templates/trojsten/events/participants_and_organizers_list.html
+++ b/trojsten/events/templates/trojsten/events/participants_and_organizers_list.html
@@ -18,10 +18,10 @@
     <th>Škola</th>
 </tr>
 </thead>
-{% for participant in event.participants %}
+{% for participant in participants %}
     <tr {% if user == participant.user %}class="active"{% endif %}>
         <td>{{ participant.user.get_full_name }}</td>
-        <td>{{ participant.user.school_year | school_year }}</td>
+        <td>{{ participant.year_at_event | school_year }}</td>
         <td>
         {% if participant.user.school.has_abbreviation %}
             <abbr title="{{ participant.user.school.verbose_name }}"
@@ -35,7 +35,7 @@
     </tr>
 {% endfor %}
 <tr><th colspan="3">Vedúci</th></tr>
-{% for organizer in event.organizers %}
+{% for organizer in organizers %}
     <tr {% if user == organizer.user %}class="active"{% endif %}>
         <td colspan="2">{{ organizer.user.get_full_name }}</td>
         <td>

--- a/trojsten/events/views.py
+++ b/trojsten/events/views.py
@@ -16,6 +16,18 @@ class ParticipantsAndOrganizersListView(DetailView):
     context_object_name = 'event'
     pk_url_kwarg = 'event_id'
 
+    def get_context_data(self, **kwargs):
+        context = super(ParticipantsAndOrganizersListView, self).get_context_data(**kwargs)
+        event = context['event']
+        participants = event.participants.select_related('user__school')
+        for participant in participants:
+            participant.year_at_event = participant.user.school_year_at(event.start_time)
+        context.update({
+            'participants': participants,
+            'organizers': event.organizers.select_related('user__school'),
+        })
+        return context
+
 
 participants_organizers_list = ParticipantsAndOrganizersListView.as_view()
 

--- a/trojsten/rules/ksp.py
+++ b/trojsten/rules/ksp.py
@@ -123,7 +123,7 @@ class KSPResultsGenerator(ResultsGenerator):
         row.cells_by_key[results_constants.LEVEL_COLUMN_KEY] = ResultsCell(str(user_level))
 
     def create_results_cols(self, res_request):
-        yield ResultsCol(key=results_constants.LEVEL_COLUMN_KEY, name='L')
+        yield ResultsCol(key=results_constants.LEVEL_COLUMN_KEY, name='Level')
         for col in super(KSPResultsGenerator, self).create_results_cols(res_request):
             yield col
 


### PR DESCRIPTION
Dokončené pravidlá KMS, aby rátali koeficienty účastníkov podľa údajov z databázy. Okrem ročníku sa ráta

- Počet úspešných semesterov z modelu `Invitation`: semestre, v ktorých sa účastník zúčastnil sústredka alebo dostal riadnu pozvánku.
- Počet účastí na celoštátkach (za minulé semestre): Celoštátka budú uchovávané ako typ akcie. Každé bude mať FK na semster podľa čoho sa určí, či sa má zarátať alebo nie.

V súvislosti s tým boli mierne upravené events, aby lepšie podporovali iné akcie ako sústredká a aby sa jednoduchšie nahadzovali účastníci, ak sa nepoužívajú pozvánky.

- Do `ParticipantInvitationInline` pridaný sĺpec `going` pre jednoduchšie nahadzovanie + tlačítko, ktorým možno nahodiť všetkým naraz Áno.
- V modeli `Event` pridaný voliteľný FK na semester. Jednoducho sa tak identifikujú sústredká KMS v tom istom semestri a celoštátka, ktoré treba rátať.
- Do fieldu `sites` v `EventType` doplnené `blank=True` pre Eventy, ktoré nechceme zobrazovať na žiadnej stránke (celoštátko).

Je to spravené tak, aby boli koeficienty správne aj s starých výsledkovkách, vyžadovalo to len jednu podmienku navyše.

Zrátanie výsledkovky má 65 queries, nerastie s počtom riešiteľov, čo som to zbežne testoval. Ak máte nejaké priestory na vylepšenie, môžete napísať.

Pre správne fungovanie je potrebné zmigrovať sústredká za posledné 3 roky (#323, #902 ) a nahodiť celoštátka. Ak nebude na to skript, tak sa to dá spraviť aj ručne nahodiť zopár sústrediek, ale aspoň starí  userovia by mohli byť vtedy zmigrovaní.

Closes #1069 