### PR TITLE
Use fixed version (2.4.6) of Elasticsearch in Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,7 @@ python:
   - "3.5"
 env:
   - DJANGO_VERSION='>=1.10,<1.11'
-# To ensure, that elasticsearch is available
-before_script:
-  - wget -q --waitretry=1 --retry-connrefused -T 10 -O - http://127.0.0.1:9200
+
 # command to install dependencies
 
 matrix:
@@ -30,6 +28,7 @@ install:
   - bash -c 'cd trojsten; python ../manage.py compilemessages;'
 # command to run tests
 script:
+  - wget -q --waitretry=1 --retry-connrefused -T 10 -O - http://127.0.0.1:9200
   - coverage run --source='./trojsten' --omit 'trojsten/settings/*,trojsten/special/*' manage.py test
 after_success:
   - bash <(curl -s https://codecov.io/bash) -t 1f124dcd-a10f-4773-90f7-6b5e304335ac


### PR DESCRIPTION
Haystack nepodporuje Elasticsearch 5.x, treba na Travise používať staršiu verziu.