### PR TITLE
Switch to new tester server

### DIFF
--- a/trojsten/submit/helpers.py
+++ b/trojsten/submit/helpers.py
@@ -27,18 +27,18 @@ def write_chunks_to_file(filepath, chunks):
 def get_lang_from_filename(filename):
     ext = os.path.splitext(filename)[1].lower()
     extmapping = {
-        ".cpp": ".cc",
-        ".cc": ".cc",
-        ".pp": ".pas",
-        ".pas": ".pas",
-        ".dpr": ".pas",
-        ".c": ".c",
-        ".py": ".py",
-        ".py3": ".py",
-        ".hs": ".hs",
-        ".cs": ".cs",
-        ".java": ".java",
-        ".zip": ".zip"}
+        ".cpp": "cc",
+        ".cc": "cc",
+        ".pp": "pas",
+        ".pas": "pas",
+        ".dpr": "pas",
+        ".c": "c",
+        ".py": "py",
+        ".py3": "py",
+        ".hs": "hs",
+        ".cs": "cs",
+        ".java": "java",
+        ".zip": "zip"}
 
     if ext not in extmapping:
         return False
@@ -106,7 +106,6 @@ def process_submit_raw(f, contest_id, task_id, language, user_id):
         lang = get_lang_from_filename(f.name)
         if not lang:
             return False
-        language = lang.strip('.')
 
     # Generate submit ID
     # Submit ID is <timestamp>-##### where ##### are 5 random digits

--- a/trojsten/submit/tests.py
+++ b/trojsten/submit/tests.py
@@ -472,7 +472,7 @@ class SubmitHelpersTests(TestCase):
             self.assertEqual(data, b'helloworld')
 
     def test_get_lang_from_filename(self):
-        self.assertEqual(get_lang_from_filename('file.cpp'), '.cc')
+        self.assertEqual(get_lang_from_filename('file.cpp'), 'cc')
         self.assertEqual(get_lang_from_filename('file.foo'), False)
 
     def test_get_path_raw(self):


### PR DESCRIPTION
Upravene podla dokumentacie `bin/interceptor-1.3/protokol.md` v `testovac@10.0.0.202`.

Otestovane z lokalne rozbehanej instancie webu na lokalnej sieti (pripojenie cez multitalenta).

Pred deployom treba zmenit nastavenia v .env subore:
tester url: 10.0.0.202 , tester port: 12347
    