### PR TITLE
Update link to MathJax repository

### DIFF
--- a/trojsten/templates/trojsten/layout/base.html
+++ b/trojsten/templates/trojsten/layout/base.html
@@ -49,7 +49,7 @@
         });
         MathJax.Ajax.config.path["Contrib"] = "//cdn.mathjax.org/mathjax/contrib";
       </script>
-      <script type="text/javascript" src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+      <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
       <script src="{% static "js/"|add:SITE.folder|add:"/analytics.js" %}" type="text/javascript"></script>
       <script src="{% static "js/fb_pixel.js" %}" type="text/javascript"></script>
       {% include "ksp_login/parts/include_javascript.html" %}


### PR DESCRIPTION
Viz. [announcement](https://www.mathjax.org/cdn-shutting-down/)

Link na pôvodný script sa zmenil na krátky script, ktorý má v sebe link a loadne script z nového linku, takže táto zmena len vyhadzuje middlemena a tvári sa to tak na oko cca 2x rýchlejšie - ~60ms voči ~140ms - môj dedinský mikrovlnkový internet, YMMW.