### PR TITLE
Try to fix deploy on beta

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,7 @@ django-sortedm2m
 django-threadedcomments
 django-tips
 django-trojsten-news
-Django<2
+Django>=1.11,<2
 djangorestframework
 ecdsa
 elasticsearch


### PR DESCRIPTION
`pip-tools` sometimes compiles requirements with older django version. Our code seems to require version 1.11