### PR TITLE
improve dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.6-alpine3.7
 
 ENV PYTHONUNBUFFERED=0
 
-RUN apk add --no-cache --virtual build-deps gcc g++ make libffi-dev musl-dev postgresql-dev jpeg-dev zlib-dev freetype-dev lcms2-dev openjpeg-dev tiff-dev tk-dev tcl-dev harfbuzz-dev fribidi-dev socat
+RUN apk add --no-cache --virtual build-deps gcc g++ make libffi-dev musl-dev postgresql-dev jpeg-dev zlib-dev freetype-dev lcms2-dev openjpeg-dev tiff-dev tk-dev tcl-dev harfbuzz-dev fribidi-dev
 
 COPY ./requirements3.devel.txt /web/requirements3.devel.txt
 WORKDIR /web

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,9 @@ services:
     image: postgres:10.1-alpine
     volumes:
       - db_data:/var/lib/postgresql/data
+    networks:
+      trojsten:
+        ipv4_address: 10.47.0.2
     environment:
       - POSTGRES_USER=trojsten
       - POSTGRES_DB=trojsten
@@ -13,6 +16,9 @@ services:
       - "8000:8000"
     volumes:
       - .:/web
+    networks:
+      trojsten:
+        ipv4_address: 10.47.0.3
     depends_on:
       - db
       - login
@@ -21,7 +27,8 @@ services:
       - TROJSTENWEB_DATABASE_URL=db
       - TROJSTENWEB_DATABASE_USER=trojsten
       - TROJSTENWEB_DATABASE_NAME=trojsten
-    command: sh docker-dev-entrypoint.sh
+      - TROJSTENWEB_LOGIN_PROVIDER_URL=http://10.47.0.4:8047
+    command: python manage.py runserver 0.0.0.0:8000
   login:
     build: .
     image: trojstenweb:latest
@@ -29,6 +36,9 @@ services:
       - "8047:8047"
     volumes:
       - .:/web
+    networks:
+      trojsten:
+        ipv4_address: 10.47.0.4
     depends_on:
       - db
     environment:
@@ -37,7 +47,14 @@ services:
       - TROJSTENWEB_DATABASE_URL=db
       - TROJSTENWEB_DATABASE_USER=trojsten
       - TROJSTENWEB_DATABASE_NAME=trojsten
+      - TROJSTENWEB_ALLOWED_HOSTS=localhost;127.0.0.1;10.47.0.4
     command: python manage.py runserver 0.0.0.0:8047
 
 volumes:
   db_data:
+
+networks:
+  trojsten:
+    ipam:
+      config:
+        - subnet: 10.47.0.0/16

--- a/docker-dev-entrypoint.sh
+++ b/docker-dev-entrypoint.sh
@@ -1,2 +1,0 @@
-socat TCP4-LISTEN:8047,reuseaddr,fork TCP4:login:8047 &
-python manage.py runserver 0.0.0.0:8000

--- a/trojsten/settings/development.py
+++ b/trojsten/settings/development.py
@@ -10,7 +10,7 @@ CACHES = {
     }
 }
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']
 DEBUG = True
 SUBMIT_DEBUG = True
 # Disable captcha


### PR DESCRIPTION
- disable pip cache (smaller images)
- cache pip installed packages in a separate docker layer (faster rebuilds if packages not changed)
- use prebuilt requirements3.devel.txt instead of building own with pip-compile (pip-compile breaks sometimes)
- tunnel development container to login development container using socat to fix login issues ( fixes #1136 )