### PR TITLE
do not run pip-compile in python 3.6 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ matrix:
 install:
   - wget https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.6/elasticsearch-2.4.6.tar.gz
   - tar -xzf elasticsearch-2.4.6.tar.gz
-  - ./elasticsearch-2.4.6/bin/elasticsearch &  
+  - ./elasticsearch-2.4.6/bin/elasticsearch &
   - if [[ $TRAVIS_PYTHON_VERSION != 2.7 ]]; then pip install -r requirements3.txt; else pip install -r requirements.txt; fi
   - pip install -q "Django${DJANGO_VERSION}"
   - pip install -q coverage


### PR DESCRIPTION
We do not run pip-compile anymore during deploy (because it sometimes doesn't work properly) and we definitely shouldn't install pip-tools from master branch during tests because master can (and currently is) be broken and then our tests don't work and we wonder why..