### PR TITLE
Don't show categories in task list if there are none

### DIFF
--- a/trojsten/contests/templates/trojsten/contests/parts/task_list.html
+++ b/trojsten/contests/templates/trojsten/contests/parts/task_list.html
@@ -41,9 +41,11 @@
         {% endif %}
     </th>
     {% endif %}
-    <th width="15%">
-        Kategória
-    </th>
+    {% if categories.count > 0 %}
+        <th width="15%">
+            Kategória
+        </th>
+    {% endif %}
     <th width="15%">
         Max. body
     </th>
@@ -67,11 +69,13 @@
                 <a href="{% url 'solution_statement' task_id=task.id %}">vzorák</a>
             </td>
         {% endif %}
-        <td>
-            {% for category in task.categories.all %}
-                <span class="label label-default category-{{ category }}">{{ category }}</span>
-            {% endfor %}
-        </td>
+        {% if categories.count > 0 %}
+            <td>
+                {% for category in task.categories.all %}
+                    <span class="label label-default category-{{ category }}">{{ category }}</span>
+                {% endfor %}
+            </td>
+        {% endif %}
         <td>
             {% if task.description_points > 0 %}
                 <span class="points-item">popis:&nbsp;{{ task.description_points }}</span>

--- a/trojsten/contests/templatetags/statements_parts.py
+++ b/trojsten/contests/templatetags/statements_parts.py
@@ -23,7 +23,7 @@ def show_task_list(context, round):
     ).select_related(
         'round', 'round__semester', 'round__semester__competition'
     )
-    categories = Category.objects.filter(competition=round.semester.competition)
+    categories = Category.objects.filter(task__in=tasks.values_list('pk', flat=True)).distinct()
 
     data = {
         'round': round,

--- a/trojsten/contests/templatetags/statements_parts.py
+++ b/trojsten/contests/templatetags/statements_parts.py
@@ -23,6 +23,7 @@ def show_task_list(context, round):
     ).select_related(
         'round', 'round__semester', 'round__semester__competition'
     )
+    # Select all categories which are represented by at least one task in displayed round.
     categories = Category.objects.filter(task__in=tasks.values_list('pk', flat=True)).distinct()
 
     data = {


### PR DESCRIPTION
Nové KSP úlohy (ani Prask a UFO)nemajú kategórie. 
Preto je zbytočné v zozname úloh zobrazovať stĺpček s kategóriami.

Po novom sa tento stĺpček zobrazí iba vtedy, ak majú úlohy v danom kole priradenú aspoň jednu kategóriu.

Closes #1096 