### PR TITLE
Call update submit at poll info, mark protocol as corrupted

### DIFF
--- a/trojsten/locale/sk/LC_MESSAGES/django.po
+++ b/trojsten/locale/sk/LC_MESSAGES/django.po
@@ -1,27 +1,30 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-12 21:28+0200\n"
+"POT-Creation-Date: 2018-06-09 17:04+0200\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-#: contact_form/forms.py:15
+#: trojsten/contact_form/forms.py:15
 msgid "Subject"
 msgstr "Predmet"
 
-#: contact_form/forms.py:22 contact_form/tests.py:63 contact_form/tests.py:72
+#: trojsten/contact_form/forms.py:22 trojsten/contact_form/tests.py:63
+#: trojsten/contact_form/tests.py:72
 msgid "Name"
 msgstr "Meno"
 
-#: contact_form/forms.py:23 contact_form/tests.py:64 contact_form/tests.py:73
+#: trojsten/contact_form/forms.py:23 trojsten/contact_form/tests.py:64
+#: trojsten/contact_form/tests.py:73
 msgid "Email"
 msgstr "E-mail"
 
-#: contact_form/forms.py:24 contact_form/tests.py:65 contact_form/tests.py:74
+#: trojsten/contact_form/forms.py:24 trojsten/contact_form/tests.py:65
+#: trojsten/contact_form/tests.py:74
 msgid "Message"
 msgstr "Správa"
 
-#: contact_form/templates/contact_form/contact_form.html:19
+#: trojsten/contact_form/templates/contact_form/contact_form.html:19
 #, python-format
 msgid ""
 "\n"
@@ -39,7 +42,7 @@ msgstr ""
 "alebo priamo vedúcemu uvedenému pri úlohe.\n"
 "    "
 
-#: contact_form/templates/contact_form/contact_form.html:29
+#: trojsten/contact_form/templates/contact_form/contact_form.html:29
 msgid ""
 "If you have found any problem with our web site, please let us know using "
 "the following form."
@@ -47,72 +50,72 @@ msgstr ""
 "Ak ste objavili chybu na našej stránke, prosím, dajte nám vedieť použitím "
 "nasledujúceho formulára."
 
-#: contests/forms.py:11
+#: trojsten/contests/forms.py:11
 msgid "Category doesn't correspond with competition."
 msgstr ""
 
 # pdf file names
-#: contests/models.py:256
+#: trojsten/contests/models.py:256
 msgid "year"
 msgstr "ročník"
 
-#: contests/models.py:258
+#: trojsten/contests/models.py:258
 msgid "round"
 msgstr "kolo"
 
-#: contests/models.py:260
+#: trojsten/contests/models.py:260
 msgid "solutions"
 msgstr "vzoráky"
 
-#: contests/models.py:260
+#: trojsten/contests/models.py:260
 msgid "tasks"
 msgstr "zadania"
 
-#: contests/models.py:399
+#: trojsten/contests/models.py:399
 #, fuzzy
 #| msgid "tasks"
 msgid "task"
 msgstr "úloha"
 
-#: contests/models.py:402
+#: trojsten/contests/models.py:402
 msgid "organizer"
 msgstr "vedúci"
 
-#: contests/models.py:405
+#: trojsten/contests/models.py:405
 msgid "reviewer"
 msgstr "opravovateľ"
 
-#: contests/models.py:406
+#: trojsten/contests/models.py:406
 #, fuzzy
 #| msgid "solution-writer"
 msgid "solution writer"
 msgstr "vzorákovač"
 
-#: contests/models.py:407
+#: trojsten/contests/models.py:407
 msgid "proofreader"
 msgstr "recenzovač"
 
-#: contests/models.py:410
+#: trojsten/contests/models.py:410
 msgid "role"
 msgstr "funkcia"
 
-#: contests/models.py:414
+#: trojsten/contests/models.py:414
 msgid "Assigned user"
 msgstr "Pridelený človek"
 
-#: contests/models.py:415
+#: trojsten/contests/models.py:415
 msgid "Assigned people"
 msgstr "Pridelení ľudia"
 
-#: contests/templates/trojsten/contests/parts/progress.html:10
+#: trojsten/contests/templates/trojsten/contests/parts/progress.html:10
 msgid "Submit programs until"
 msgstr "Doprogramovanie do"
 
-#: contests/templates/trojsten/contests/parts/progress.html:12
+#: trojsten/contests/templates/trojsten/contests/parts/progress.html:12
 msgid "End of the round"
 msgstr "Koniec kola"
 
-#: contests/templates/trojsten/contests/parts/progress.html:26
+#: trojsten/contests/templates/trojsten/contests/parts/progress.html:26
 msgid ""
 "\n"
 "      Don't submit descriptions.\n"
@@ -126,130 +129,131 @@ msgstr ""
 "ktoré dostanete časť bodov.\n"
 "      "
 
-#: contests/templates/trojsten/contests/parts/progress.html:36
+#: trojsten/contests/templates/trojsten/contests/parts/progress.html:36
 msgid "The round has finished."
 msgstr "Kolo už skončilo."
 
-#: contests/templates/trojsten/contests/parts/progress.html:39
+#: trojsten/contests/templates/trojsten/contests/parts/progress.html:39
 msgid "View the solution."
 msgstr "Pozrieť vzorové riešenie."
 
 # Task Statements
-#: contests/templatetags/statements_parts.py:98
+#: trojsten/contests/templatetags/statements_parts.py:98
 #, fuzzy, python-format
 #| msgid "%(count)d day"
 #| msgid_plural "%(count)s days"
 msgid "%(count)d day"
 msgstr "%(count)s deň"
 
-#: contests/templatetags/statements_parts.py:101
+#: trojsten/contests/templatetags/statements_parts.py:101
 #, fuzzy, python-format
 #| msgid "%(count)d hour"
 #| msgid_plural "%(count)s hours"
 msgid "%(count)d hour"
 msgstr "%(count)s hodina"
 
-#: contests/templatetags/statements_parts.py:104
+#: trojsten/contests/templatetags/statements_parts.py:104
 #, fuzzy, python-format
 #| msgid "%(count)d minute"
 #| msgid_plural "%(count)s minutes"
 msgid "%(count)d minute"
 msgstr "%(count)s minúta"
 
-#: contests/templatetags/statements_parts.py:107
+#: trojsten/contests/templatetags/statements_parts.py:107
 #, fuzzy, python-format
 #| msgid "%(count)d second"
 #| msgid_plural "%(count)s seconds"
 msgid "%(count)d second"
 msgstr "%(count)s sekunda"
 
-#: login/views.py:29
+#: trojsten/login/views.py:29
 msgid "Logout successful"
 msgstr "Odhlásenie úspešné"
 
-#: people/admin.py:157
+#: trojsten/people/admin.py:157
 msgid "Personal info"
 msgstr "Osobné údaje"
 
-#: people/admin.py:160
+#: trojsten/people/admin.py:160
 msgid "Address"
 msgstr "Adresa"
 
-#: people/admin.py:161
+#: trojsten/people/admin.py:161
 msgid "School"
 msgstr "Škola"
 
-#: people/admin.py:164 people/forms.py:271
+#: trojsten/people/admin.py:164 trojsten/people/forms.py:271
 msgid "Password"
 msgstr "Heslo"
 
-#: people/admin.py:165
+#: trojsten/people/admin.py:165
 msgid "Permissions"
 msgstr "Práva"
 
-#: people/admin.py:168
+#: trojsten/people/admin.py:168
 msgid "Important dates"
 msgstr "Dôležité dátumy"
 
-#: people/admin.py:257
+#: trojsten/people/admin.py:257
 msgid "Users merged succesfully."
 msgstr "Používatelia spojení úspešne."
 
-#: people/forms.py:31 people/forms.py:49
+#: trojsten/people/forms.py:31 trojsten/people/forms.py:49
 msgid "Street"
 msgstr "Ulica"
 
-#: people/forms.py:32 people/forms.py:50
+#: trojsten/people/forms.py:32 trojsten/people/forms.py:50
 msgid "Town"
 msgstr "Mesto"
 
-#: people/forms.py:34 people/forms.py:52
+#: trojsten/people/forms.py:34 trojsten/people/forms.py:52
 msgid "Postal code"
 msgstr "PSČ"
 
-#: people/forms.py:35 people/forms.py:54
+#: trojsten/people/forms.py:35 trojsten/people/forms.py:54
 msgid "Country"
 msgstr "Krajina"
 
-#: people/forms.py:38
+#: trojsten/people/forms.py:38
 msgid "home"
 msgstr "domov"
 
-#: people/forms.py:39
+#: trojsten/people/forms.py:39
 msgid "school"
 msgstr "do školy"
 
-#: people/forms.py:40
+#: trojsten/people/forms.py:40
 msgid "other address (e. g. to a dormitory)"
 msgstr "na inú adresu (napr. na internát)"
 
-#: people/forms.py:44
+#: trojsten/people/forms.py:44
 msgid "Correspondence address"
 msgstr "Korešpondenčná adresa"
 
-#: people/forms.py:45
+#: trojsten/people/forms.py:45
 msgid "Choose, where you want to accept mails."
 msgstr "Vyber, kam ti máme posielať poštu."
 
-#: people/forms.py:72
+#: trojsten/people/forms.py:72
 msgid "Gender"
 msgstr "Pohlavie"
 
-#: people/forms.py:88 people/forms.py:96 people/forms.py:104
-#: people/forms.py:113 people/forms.py:123 people/forms.py:133
-#: people/forms.py:143
+#: trojsten/people/forms.py:88 trojsten/people/forms.py:96
+#: trojsten/people/forms.py:104 trojsten/people/forms.py:113
+#: trojsten/people/forms.py:123 trojsten/people/forms.py:133
+#: trojsten/people/forms.py:143
 msgid "This field is required."
 msgstr "Toto pole je povinné."
 
-#: people/forms.py:154
+#: trojsten/people/forms.py:154
 msgid "Your graduation year is too far in the past."
 msgstr "Tvoj rok maturity je príliš ďaleko v minulosti."
 
-#: people/forms.py:160
+#: trojsten/people/forms.py:160
 msgid "Your graduation year is too far in the future."
 msgstr "Tvoj rok maturity je príliš ďaleko v budúcnosti."
 
-#: people/forms.py:172
+#: trojsten/people/forms.py:172
 msgid ""
 "We cannot send you correspondence to school when you don't choose any "
 "school. If your school is not in the list write us in an e-mail that you "
@@ -259,15 +263,15 @@ msgstr ""
 "tvoja škola nenachádza v zozname, napíš v e-maili, že ti máme posielať poštu "
 "na školu"
 
-#: people/forms.py:273
+#: trojsten/people/forms.py:273
 msgid "Password confirmation"
 msgstr "Potvrdenie hesla"
 
-#: people/forms.py:274
+#: trojsten/people/forms.py:274
 msgid "Enter the same password as above, for verification."
 msgstr "Zadaj rovnaké heslo ako vyššie pre jeho overenie"
 
-#: people/forms.py:300
+#: trojsten/people/forms.py:300
 msgid ""
 "We recommend choosing a strong passphrase but we don't enforce any "
 "ridiculous constraints on your passwords."
@@ -275,90 +279,90 @@ msgstr ""
 "Odporúčame ti vybrať silné heslo, ale nebudeme od teba vyžadovať žiadne "
 "smiešne požiadavky"
 
-#: people/forms.py:308
+#: trojsten/people/forms.py:308
 msgid ""
 "Since you're logging in using an external provider, this field is optional; "
 "however, by supplying it, you will be able to log in using a password. "
 msgstr ""
 
-#: people/forms.py:318
+#: trojsten/people/forms.py:318
 msgid "The two password fields didn't match."
 msgstr ""
 
-#: people/forms.py:457
+#: trojsten/people/forms.py:457
 msgid "Points have to be non-negative and at most {}."
 msgstr "Body musia byť nezáporné a najviac {}."
 
-#: people/forms.py:462
+#: trojsten/people/forms.py:462
 #, fuzzy
 #| msgid "The value has to be integer or {}."
 msgid "The value has to be number or {}."
 msgstr "Hodnota musí byť číslo alebo {}."
 
-#: people/forms.py:506
+#: trojsten/people/forms.py:506
 msgid "Round"
 msgstr "Kolo"
 
-#: people/forms.py:520 people/forms.py:558
-#: people/templates/admin/people/duplicateuser/merge_duplicate_users.html:31
-#: people/templates/trojsten/people/settings.html:95
-#: templates/ksp_login/parts/multiple_forms.html:11
-#: templates/ksp_login/parts/single_form.html:10
+#: trojsten/people/forms.py:520 trojsten/people/forms.py:558
+#: trojsten/people/templates/admin/people/duplicateuser/merge_duplicate_users.html:31
+#: trojsten/people/templates/trojsten/people/settings.html:95
+#: trojsten/templates/ksp_login/parts/multiple_forms.html:11
+#: trojsten/templates/ksp_login/parts/single_form.html:10
 msgid "Submit"
 msgstr "Odoslať"
 
-#: people/models.py:220
+#: trojsten/people/models.py:220
 msgid "Value \"{}\" does not match regex \"{}\"."
 msgstr ""
 
-#: people/templates/admin/people/duplicateuser/change_form.html:5
+#: trojsten/people/templates/admin/people/duplicateuser/change_form.html:5
 msgid "Merge candidates"
 msgstr ""
 
-#: people/templates/admin/people/duplicateuser/change_form.html:11
-#: people/templates/admin/people/duplicateuser/merge_duplicate_users.html:10
+#: trojsten/people/templates/admin/people/duplicateuser/change_form.html:11
+#: trojsten/people/templates/admin/people/duplicateuser/merge_duplicate_users.html:10
 msgid "Merge"
 msgstr ""
 
-#: people/templates/admin/people/duplicateuser/merge_duplicate_users.html:6
-#: people/templates/admin/people/submitted_tasks.html:6
-#: reviews/templates/admin/review_edit.html:6
-#: reviews/templates/admin/review_form.html:6
-#: reviews/templates/admin/zip_upload.html:6
+#: trojsten/people/templates/admin/people/duplicateuser/merge_duplicate_users.html:6
+#: trojsten/people/templates/admin/people/submitted_tasks.html:6
+#: trojsten/reviews/templates/admin/review_edit.html:6
+#: trojsten/reviews/templates/admin/review_form.html:6
+#: trojsten/reviews/templates/admin/zip_upload.html:6
 msgid "Home"
 msgstr ""
 
-#: people/templates/admin/people/duplicateuser/merge_duplicate_users.html:16
+#: trojsten/people/templates/admin/people/duplicateuser/merge_duplicate_users.html:16
 #, python-format
 msgid "Merge users %(user)s and %(candidate)s"
 msgstr ""
 
-#: people/templates/admin/people/duplicateuser/merge_duplicate_users.html:32
+#: trojsten/people/templates/admin/people/duplicateuser/merge_duplicate_users.html:32
 msgid "Reset"
 msgstr "Obnoviť"
 
-#: people/templates/admin/people/duplicateuser/merge_duplicate_users.html:33
+#: trojsten/people/templates/admin/people/duplicateuser/merge_duplicate_users.html:33
 msgid "Cancel"
 msgstr "Zrušiť"
 
-#: people/templates/admin/people/submitted_tasks.html:7
+#: trojsten/people/templates/admin/people/submitted_tasks.html:7
 msgid "People"
 msgstr "Ľudia"
 
-#: people/templates/admin/people/submitted_tasks.html:8
+#: trojsten/people/templates/admin/people/submitted_tasks.html:8
 msgid "Users"
 msgstr "Používatelia"
 
-#: people/templates/admin/people/submitted_tasks.html:10
-#: people/templates/admin/people/submitted_tasks_button.html:6
+#: trojsten/people/templates/admin/people/submitted_tasks.html:10
+#: trojsten/people/templates/admin/people/submitted_tasks_button.html:6
 msgid "Submitted tasks"
 msgstr "Odovzdané úlohy"
 
-#: people/templates/admin/people/submitted_tasks.html:15
+#: trojsten/people/templates/admin/people/submitted_tasks.html:15
 msgid "Tasks submitted by competitor"
 msgstr "Úlohy odovzdané riešiteľom"
 
-#: people/templates/admin/people/submitted_tasks.html:16
+#: trojsten/people/templates/admin/people/submitted_tasks.html:16
 msgid ""
 "\n"
 "You are viewing submits for round:\n"
@@ -366,11 +370,11 @@ msgstr ""
 "\n"
 "Prezeráš si odovzdané úlohy pre kolo:\n"
 
-#: people/templates/admin/people/submitted_tasks.html:23
+#: trojsten/people/templates/admin/people/submitted_tasks.html:23
 msgid "Change round"
 msgstr "Zmeň kolo"
 
-#: people/templates/admin/people/submitted_tasks.html:27
+#: trojsten/people/templates/admin/people/submitted_tasks.html:27
 #, python-format
 msgid ""
 "\n"
@@ -391,23 +395,23 @@ msgstr ""
 "Políčkami môžeš prechádzať pomocou tabulátora.\n"
 
 # Login
-#: people/templates/trojsten/people/additional_registration.html:11
-#: people/templates/trojsten/people/additional_registration.html:14
+#: trojsten/people/templates/trojsten/people/additional_registration.html:11
+#: trojsten/people/templates/trojsten/people/additional_registration.html:14
 #, fuzzy
 #| msgid "Registration"
 msgid "Complete Registration"
 msgstr "Dodatočná Registrácia"
 
-#: people/templates/trojsten/people/additional_registration.html:23
-#: people/tests.py:759
+#: trojsten/people/templates/trojsten/people/additional_registration.html:23
+#: trojsten/people/tests.py:759
 msgid "You have already filled all required properties."
 msgstr "Momentálne máš vyplnené všetky potrebné údaje."
 
-#: people/templates/trojsten/people/parts/additional_registration.html:9
+#: trojsten/people/templates/trojsten/people/parts/additional_registration.html:9
 msgid "We need a little more information"
 msgstr "Potrebujeme ešte zopár údajov"
 
-#: people/templates/trojsten/people/parts/additional_registration.html:13
+#: trojsten/people/templates/trojsten/people/parts/additional_registration.html:13
 msgid ""
 "To participate in some competitions, we need you to fill some more data in "
 "addition to those you have filled during registration.\n"
@@ -417,7 +421,7 @@ msgstr ""
 "údaje navyše okrem tých, ktoré si zadal pri registrácii. Pokiaľ ich "
 "nevyplníš, nebudeme ťa zobrazovať vo výsledkovej listine."
 
-#: people/templates/trojsten/people/parts/additional_registration.html:17
+#: trojsten/people/templates/trojsten/people/parts/additional_registration.html:17
 msgid ""
 "If you want to prevent this message from showing, you may check \"I do not "
 "want to participate in competition\".\n"
@@ -427,7 +431,7 @@ msgstr ""
 "\"Nechcem sa zapojiť do súťaže\". Toto rozhodnutie môžeš neskôr zmeniť v "
 "nastaveniach v sekcii \"Súťaže\"."
 
-#: people/templates/trojsten/people/parts/additional_registration.html:22
+#: trojsten/people/templates/trojsten/people/parts/additional_registration.html:22
 #, python-format
 msgid ""
 "To participate in competition <em>%(competition)s</em> you need to fill:"
@@ -435,70 +439,71 @@ msgstr ""
 "V súťaži <em>%(competition)s</em> potrebujeme ešte aby si vyplnil tieto "
 "údaje:"
 
-#: people/templates/trojsten/people/parts/additional_registration.html:33
+#: trojsten/people/templates/trojsten/people/parts/additional_registration.html:33
 #, python-format
 msgid "I do not want to participate in competition %(competition)s."
 msgstr "Nechcem sa zapojiť do súťaže %(competition)s."
 
-#: people/templates/trojsten/people/parts/additional_registration.html:37
+#: trojsten/people/templates/trojsten/people/parts/additional_registration.html:37
 msgid "Close"
 msgstr "Zavrieť"
 
-#: people/templates/trojsten/people/parts/additional_registration.html:38
+#: trojsten/people/templates/trojsten/people/parts/additional_registration.html:38
 msgid "Fill data"
 msgstr "Vyplniť údaje"
 
-#: people/templates/trojsten/people/settings.html:11
-#: people/templates/trojsten/people/settings.html:14
+#: trojsten/people/templates/trojsten/people/settings.html:11
+#: trojsten/people/templates/trojsten/people/settings.html:14
 #, fuzzy
 #| msgid "Account information"
 msgid "Account settings"
 msgstr "Nastavenia účtu"
 
-#: people/templates/trojsten/people/settings.html:21
+#: trojsten/people/templates/trojsten/people/settings.html:21
 msgid "Profile"
 msgstr "Profil"
 
-#: people/templates/trojsten/people/settings.html:22
+#: trojsten/people/templates/trojsten/people/settings.html:22
 msgid "Properties"
 msgstr "Vlastnosti"
 
-#: people/templates/trojsten/people/settings.html:23
-#: reviews/templates/admin/review_form.html:7
-#: reviews/templates/admin/zip_upload.html:7
+#: trojsten/people/templates/trojsten/people/settings.html:23
+#: trojsten/reviews/templates/admin/review_form.html:7
+#: trojsten/reviews/templates/admin/zip_upload.html:7
 msgid "Contests"
 msgstr "Súťaže"
 
-#: people/templates/trojsten/people/settings.html:25
-#: people/templates/trojsten/people/settings.html:27
+#: trojsten/people/templates/trojsten/people/settings.html:25
+#: trojsten/people/templates/trojsten/people/settings.html:27
 msgid "Login settings"
 msgstr "Nastavenia prihlasovania"
 
-#: people/templates/trojsten/people/settings.html:96
+#: trojsten/people/templates/trojsten/people/settings.html:96
 msgid "Add property"
 msgstr "Pridať vlastnosť"
 
-#: people/templates/trojsten/people/settings.html:104
+#: trojsten/people/templates/trojsten/people/settings.html:104
 msgid "Choose which competitions would you like to participate in:"
 msgstr "Vyber si súťaže, ktoré chceš riešiť:"
 
-#: people/templates/trojsten/people/settings.html:112
+#: trojsten/people/templates/trojsten/people/settings.html:112
 msgid "You can use any of the following services to log in to your account."
 msgstr "Možete použiť ľubovoľnú z nasledujúcich služieb na prihlásenie."
 
-#: people/templates/trojsten/people/settings.html:133
-#: templates/ksp_login/login.html:4 templates/ksp_login/login.html:7
-#: templates/ksp_login/parts/include_javascript.html:15
-#: templates/ksp_login/parts/login_box.html:44
-#: templates/ksp_login/parts/login_box.html:61
-#: templates/ksp_login/parts/login_box.html:75
-#: templates/ksp_login/parts/login_full_contents.html:47
-#: templates/ksp_login/parts/login_full_contents.html:53
-#: templates/ksp_login/parts/login_full_contents.html:82
+#: trojsten/people/templates/trojsten/people/settings.html:133
+#: trojsten/templates/ksp_login/login.html:4
+#: trojsten/templates/ksp_login/login.html:7
+#: trojsten/templates/ksp_login/parts/include_javascript.html:15
+#: trojsten/templates/ksp_login/parts/login_box.html:44
+#: trojsten/templates/ksp_login/parts/login_box.html:61
+#: trojsten/templates/ksp_login/parts/login_box.html:75
+#: trojsten/templates/ksp_login/parts/login_full_contents.html:47
+#: trojsten/templates/ksp_login/parts/login_full_contents.html:53
+#: trojsten/templates/ksp_login/parts/login_full_contents.html:82
 msgid "Log in"
 msgstr "Prihlásiť sa"
 
-#: people/templates/trojsten/people/settings.html:141
+#: trojsten/people/templates/trojsten/people/settings.html:141
 #, python-format
 msgid ""
 "\n"
@@ -513,12 +518,13 @@ msgstr ""
 "stránke</a>.\n"
 "                "
 
-#: people/templates/trojsten/people/settings.html:146
-#: templates/ksp_login/password.html:5 templates/ksp_login/password.html:8
+#: trojsten/people/templates/trojsten/people/settings.html:146
+#: trojsten/templates/ksp_login/password.html:5
+#: trojsten/templates/ksp_login/password.html:8
 msgid "Password change"
 msgstr "Zmena hesla"
 
-#: people/templates/trojsten/people/settings.html:149
+#: trojsten/people/templates/trojsten/people/settings.html:149
 #, python-format
 msgid ""
 "\n"
@@ -531,245 +537,249 @@ msgstr ""
 "a>.\n"
 "                "
 
-#: reviews/forms.py:49
+#: trojsten/reviews/forms.py:49
 #, python-format
 msgid "File must be a ZIP archive: %s"
 msgstr "Súbor musí byť ZIP archív: %s"
 
-#: reviews/forms.py:86
+#: trojsten/reviews/forms.py:86
 msgid "Points are required"
 msgstr "Body sú povinné"
 
-#: reviews/forms.py:89
+#: trojsten/reviews/forms.py:89
 msgid "User is required"
 msgstr "Používateľ je povinný"
 
-#: reviews/forms.py:94
+#: trojsten/reviews/forms.py:94
 #, python-format
 msgid "User %s does not exist"
 msgstr "Používateľ %s neexistuje"
 
-#: reviews/forms.py:185
+#: trojsten/reviews/forms.py:185
 #, python-format
 msgid "Invalid filename %s"
 msgstr "Neplatný názov súboru %s"
 
-#: reviews/forms.py:188
+#: trojsten/reviews/forms.py:188
 msgid "Must have set points"
 msgstr "Musíš uviesť body"
 
-#: reviews/forms.py:206
+#: trojsten/reviews/forms.py:206
 msgid "Assigned 2 or more files to the same user."
 msgstr "Rovnaký používateľ má priradené 2 alebo viac súborov."
 
-#: reviews/helpers.py:17
+#: trojsten/reviews/helpers.py:17
 msgid "You should upload a file or specify parent submit."
 msgstr "Mal by si nahrať súbor alebo špecifikovať predchádzajúci submit."
 
-#: reviews/templates/admin/review_edit.html:10
-#: reviews/templates/admin/review_form.html:10
-#: reviews/templates/admin/task_review.html:6
-#: reviews/templates/admin/zip_upload.html:10
+#: trojsten/reviews/templates/admin/review_edit.html:10
+#: trojsten/reviews/templates/admin/review_form.html:10
+#: trojsten/reviews/templates/admin/task_review.html:6
+#: trojsten/reviews/templates/admin/zip_upload.html:10
 msgid "Review"
 msgstr "Opravovanie"
 
-#: reviews/templates/admin/review_edit.html:11
-#: reviews/templates/admin/review_form.html:64
+#: trojsten/reviews/templates/admin/review_edit.html:11
+#: trojsten/reviews/templates/admin/review_form.html:64
 msgid "Edit"
 msgstr "Upraviť"
 
-#: reviews/templates/admin/review_form.html:8
-#: reviews/templates/admin/zip_upload.html:8
+#: trojsten/reviews/templates/admin/review_form.html:8
+#: trojsten/reviews/templates/admin/zip_upload.html:8
 msgid "Task"
 msgstr "Úloha"
 
-#: reviews/templates/admin/review_form.html:18
+#: trojsten/reviews/templates/admin/review_form.html:18
 msgid "Download all original solutions"
 msgstr "Stiahnuť všetky pôvodné riešenia"
 
-#: reviews/templates/admin/review_form.html:19
+#: trojsten/reviews/templates/admin/review_form.html:19
 msgid " (it downloads last submitted solution for each competitor)"
 msgstr " (stiahne pre každého užívateľa posledné odovzdané riešenie)"
 
-#: reviews/templates/admin/review_form.html:21
+#: trojsten/reviews/templates/admin/review_form.html:21
 msgid "Download all reviewed solutions"
 msgstr "Stiahnuť všetky opravené riešenia"
 
-#: reviews/templates/admin/review_form.html:22
+#: trojsten/reviews/templates/admin/review_form.html:22
 msgid " (it downloads reviewed solutions for each competitor if there is any)"
 msgstr " (stiahne pre každého užívateľa opravené riešenie, ak je opravené)"
 
-#: reviews/templates/admin/review_form.html:57
-#: reviews/templates/admin/submit_form.html:12
-#: submit/templates/trojsten/submit/parts/submit_list.html:30
-#: submit/templates/trojsten/submit/parts/submit_list.html:36
-#: submit/templates/trojsten/submit/parts/submits_for_user_and_round.html:40
-#: submit/templates/trojsten/submit/parts/submits_for_user_and_round.html:47
+#: trojsten/reviews/templates/admin/review_form.html:57
+#: trojsten/reviews/templates/admin/submit_form.html:12
+#: trojsten/submit/templates/trojsten/submit/parts/submit_list.html:30
+#: trojsten/submit/templates/trojsten/submit/parts/submit_list.html:36
+#: trojsten/submit/templates/trojsten/submit/parts/submits_for_user_and_round.html:30
+#: trojsten/submit/templates/trojsten/submit/parts/submits_for_user_and_round.html:37
 msgid "Download"
 msgstr "Stiahnuť"
 
-#: reviews/templates/admin/review_form.html:63
-#: reviews/templates/admin/submit_form.html:9
+#: trojsten/reviews/templates/admin/review_form.html:63
+#: trojsten/reviews/templates/admin/submit_form.html:9
 msgid "View"
 msgstr "Pozrieť"
 
-#: reviews/templates/admin/review_form.html:67
+#: trojsten/reviews/templates/admin/review_form.html:67
 msgid "Add new review"
 msgstr "Pridaj opravenie"
 
-#: reviews/templates/admin/review_form.html:82
+#: trojsten/reviews/templates/admin/review_form.html:82
 msgid "Update points and comments"
 msgstr "Aktualizuj body a komentáre"
 
-#: reviews/templates/admin/submit_form.html:6
+#: trojsten/reviews/templates/admin/submit_form.html:6
 msgid "View task"
 msgstr "Pozrieť úlohu"
 
-#: reviews/templates/admin/zip_upload.html:11
+#: trojsten/reviews/templates/admin/zip_upload.html:11
 msgid "Upload Zip"
 msgstr "Nahraj Zip"
 
-#: reviews/templates/admin/zip_upload.html:31
+#: trojsten/reviews/templates/admin/zip_upload.html:31
 msgid "Filename"
 msgstr "Názov súboru"
 
-#: reviews/templates/admin/zip_upload.html:32
+#: trojsten/reviews/templates/admin/zip_upload.html:32
 msgid "User"
 msgstr "Používateľ"
 
-#: reviews/templates/admin/zip_upload.html:33
+#: trojsten/reviews/templates/admin/zip_upload.html:33
 msgid "Points"
 msgstr "Body"
 
-#: reviews/templates/admin/zip_upload.html:34
+#: trojsten/reviews/templates/admin/zip_upload.html:34
 msgid "Comment"
 msgstr "Komentár"
 
-#: reviews/views.py:56
+#: trojsten/reviews/views.py:56
 msgid "Successfully uploaded a zip file."
 msgstr "Zip súbor bol úspešne nahraný"
 
-#: reviews/views.py:66
+#: trojsten/reviews/views.py:66
 msgid "Points and comments were successfully updated."
 msgstr "Body a komentáre boli úspešne aktualizované"
 
-#: reviews/views.py:127
+#: trojsten/reviews/views.py:127
 msgid "Successfully saved the review"
 msgstr "Opravenie bolo úspešne uložené"
 
-#: reviews/views.py:190
+#: trojsten/reviews/views.py:190
 #, python-format
 msgid "Missing file of user %s"
 msgstr "Chýba súbor používateľa %s"
 
-#: reviews/views.py:203
+#: trojsten/reviews/views.py:203
 #, python-format
 msgid "Missing source file of user %s"
 msgstr "Chýba zdrojový súbor používateľa %s"
 
-#: reviews/views.py:208
+#: trojsten/reviews/views.py:208
 #, python-format
 msgid "Missing protocol file of user %s"
 msgstr "Chýba protokol používateľa %s"
 
-#: reviews/views.py:244
+#: trojsten/reviews/views.py:244
 msgid "Problems with uploaded zip"
 msgstr "Problémy s nahratým zip-om"
 
-#: reviews/views.py:250
+#: trojsten/reviews/views.py:250
 msgid "Ignore"
 msgstr "Ignorovať"
 
-#: reviews/views.py:295
+#: trojsten/reviews/views.py:295
 msgid "Successfully finished reviewing this task!"
 msgstr "Úspešne dokončené opravovanie tejto úlohy!"
 
-#: settings/common.py:419
+#: trojsten/settings/common.py:424
 msgid "Table of Contents"
 msgstr ""
 
-#: submit/constants.py:11
+#: trojsten/submit/constants.py:11
 msgid "reviewed"
 msgstr "opravený"
 
-#: submit/constants.py:12
+#: trojsten/submit/constants.py:12
 msgid "in queue"
 msgstr "v poradí"
 
-#: submit/constants.py:13
+#: trojsten/submit/constants.py:13
 msgid "finished"
 msgstr "ukončený"
 
-#: submit/constants.py:14 submit/constants.py:37
+#: trojsten/submit/constants.py:14 trojsten/submit/constants.py:38
 msgid "OK"
 msgstr "OK"
 
 # Submit
-#: submit/constants.py:33 submit/tests.py:389
+#: trojsten/submit/constants.py:34 trojsten/submit/tests.py:389
 msgid "Wrong answer"
 msgstr "Zlá odpoveď"
 
-#: submit/constants.py:34
+#: trojsten/submit/constants.py:35
 msgid "Compilation error"
 msgstr "Chyba počas kompilácie"
 
-#: submit/constants.py:35
+#: trojsten/submit/constants.py:36
 msgid "Time limit exceeded"
 msgstr "Prekročený časový limit"
 
-#: submit/constants.py:36
+#: trojsten/submit/constants.py:37
 msgid "Memory limit exceeded"
 msgstr "Prekročený pamäťový limit"
 
-#: submit/constants.py:38
+#: trojsten/submit/constants.py:39
 msgid "Runtime exception"
 msgstr "Chyba počas behu programu"
 
-#: submit/constants.py:39
+#: trojsten/submit/constants.py:40
 msgid "Security exception"
 msgstr "Pokus o narušenie bezpečnosti"
 
-#: submit/constants.py:40
+#: trojsten/submit/constants.py:41
 msgid "Ignored"
 msgstr ""
 
-#: submit/forms.py:76
+#: trojsten/submit/constants.py:42
+msgid "Protocol corrupted"
+msgstr "Nečitateľný protokol"
+
+#: trojsten/submit/forms.py:76
 #, fuzzy
 #| msgid "Submit"
 msgid "Submit file"
 msgstr "Nahrať súbor"
 
-#: submit/forms.py:77
+#: trojsten/submit/forms.py:77
 msgid "Here you can upload a file with submit description"
 msgstr "Tu môžeš nahrať súbor s popisom riešenia"
 
-#: submit/forms.py:85
+#: trojsten/submit/forms.py:85
 msgid "You can attach a submit file only to descriptions."
 msgstr "Nahrať súbor môžeš len k popisom."
 
-#: submit/templates/trojsten/submit/all_submits_page.html:12
-#: submit/templates/trojsten/submit/all_submits_page.html:15
+#: trojsten/submit/templates/trojsten/submit/all_submits_page.html:7
+#: trojsten/submit/templates/trojsten/submit/all_submits_page.html:10
 msgid "My submitted tasks"
 msgstr "Moje odovzdané úlohy"
 
-#: submit/templates/trojsten/submit/parts/submit_list.html:37
+#: trojsten/submit/templates/trojsten/submit/parts/submit_list.html:37
 msgid "Show comment"
 msgstr "Pozri komentár"
 
-#: submit/templates/trojsten/submit/parts/submit_list.html:75
-#: submit/templates/trojsten/submit/parts/submit_list.html:92
+#: trojsten/submit/templates/trojsten/submit/parts/submit_list.html:75
+#: trojsten/submit/templates/trojsten/submit/parts/submit_list.html:92
 msgid "Detaily"
 msgstr ""
 
-#: submit/templates/trojsten/submit/parts/submits_for_user_and_round.html:49
+#: trojsten/submit/templates/trojsten/submit/parts/submits_for_user_and_round.html:39
 msgid "View comment"
 msgstr "Pozri komentár"
 
-#: submit/templates/trojsten/submit/parts/submits_for_user_and_round.html:70
+#: trojsten/submit/templates/trojsten/submit/parts/submits_for_user_and_round.html:53
 msgid "Details"
 msgstr "Detaily"
 
-#: submit/views.py:393
+#: trojsten/submit/views.py:397
 msgid ""
 "You have successfully submitted your description, it will be reviewed after "
 "the round finishes."
@@ -777,7 +787,7 @@ msgstr ""
 "Úspešne sa ti podarilo submitnúť popis, po skončení kola ti ho vedúci "
 "opravia."
 
-#: submit/views.py:397
+#: trojsten/submit/views.py:401
 msgid ""
 "You have submitted your description after the deadline. It is not counted in "
 "results."
@@ -785,96 +795,97 @@ msgstr ""
 "Nahral si svoj popis riešenia po termíne kola. Nebude zarátaný vo "
 "výsledkovke."
 
-#: templates/comments/comment.html:23
+#: trojsten/templates/comments/comment.html:23
 msgid "Preview of your comment"
 msgstr "Náhľad komentára"
 
-#: templates/comments/comment.html:32
+#: trojsten/templates/comments/comment.html:32
 msgid "Anonymous"
 msgstr "Anonym"
 
-#: templates/comments/comment.html:39
+#: trojsten/templates/comments/comment.html:39
 #, python-format
 msgid "on %(submit_date)s"
 msgstr "%(submit_date)s"
 
-#: templates/comments/comment.html:46
+#: trojsten/templates/comments/comment.html:46
 msgid "reply"
 msgstr "reagovať"
 
-#: templates/comments/form.html:4
+#: trojsten/templates/comments/form.html:4
 msgid "Comments are closed."
 msgstr "Diskusia je uzavretá."
 
-#: templates/comments/form.html:24
+#: trojsten/templates/comments/form.html:24
 msgid "Post"
 msgstr "Odoslať"
 
-#: templates/ksp_login/parts/associated_accounts_list.html:9
+#: trojsten/templates/ksp_login/parts/associated_accounts_list.html:9
 msgid "Provider"
 msgstr ""
 
-#: templates/ksp_login/parts/associated_accounts_list.html:10
+#: trojsten/templates/ksp_login/parts/associated_accounts_list.html:10
 msgid "Account"
 msgstr ""
 
-#: templates/ksp_login/parts/associated_accounts_list.html:32
+#: trojsten/templates/ksp_login/parts/associated_accounts_list.html:32
 msgid "Disconnect"
 msgstr ""
 
-#: templates/ksp_login/parts/associated_accounts_list.html:42
+#: trojsten/templates/ksp_login/parts/associated_accounts_list.html:42
 msgid "You don't have any services associated with your account."
 msgstr ""
 
-#: templates/ksp_login/parts/login_box.html:11
+#: trojsten/templates/ksp_login/parts/login_box.html:11
 msgid "Logged in as"
 msgstr ""
 
 # Login
-#: templates/ksp_login/parts/login_box.html:22
+#: trojsten/templates/ksp_login/parts/login_box.html:22
 #, fuzzy
 #| msgid "Registration"
 msgid "Site administration"
 msgstr "Registrácia"
 
-#: templates/ksp_login/parts/login_box.html:29
+#: trojsten/templates/ksp_login/parts/login_box.html:29
 msgid "Settings"
 msgstr ""
 
-#: templates/ksp_login/parts/login_box.html:38
+#: trojsten/templates/ksp_login/parts/login_box.html:38
 msgid "Log out"
 msgstr ""
 
-#: templates/ksp_login/parts/login_box.html:67
+#: trojsten/templates/ksp_login/parts/login_box.html:67
 msgid "More login options"
 msgstr ""
 
-#: templates/ksp_login/parts/login_full_contents.html:85
+#: trojsten/templates/ksp_login/parts/login_full_contents.html:85
 msgid "Forgotten password"
 msgstr ""
 
 # Login
-#: templates/ksp_login/parts/login_full_contents.html:96
-#: templates/ksp_login/registration.html:5
-#: templates/ksp_login/registration.html:8
+#: trojsten/templates/ksp_login/parts/login_full_contents.html:96
+#: trojsten/templates/ksp_login/registration.html:5
+#: trojsten/templates/ksp_login/registration.html:8
 msgid "Registration"
 msgstr "Registrácia"
 
-#: templates/ksp_login/parts/login_full_contents.html:112
+#: trojsten/templates/ksp_login/parts/login_full_contents.html:112
 msgid "Log in with your Trojsten account"
 msgstr ""
 
-#: templates/ksp_login/registration.html:14
+#: trojsten/templates/ksp_login/registration.html:14
 msgid ""
 "Welcome, new user. You only need to give us a few details in order to finish "
 "the registration process."
 msgstr ""
 
-#: templates/search/search.html:5 templates/search/search.html:9
+#: trojsten/templates/search/search.html:5
+#: trojsten/templates/search/search.html:9
 msgid "Search results for:"
 msgstr "Výsledky hľadania pre"
 
-#: templates/search/search.html:23
+#: trojsten/templates/search/search.html:23
 #, python-format
 msgid ""
 "\n"
@@ -883,31 +894,33 @@ msgstr ""
 "\n"
 "          Nájdených <strong>%(cnt)s</strong> výskytov."
 
-#: templates/search/search.html:32
+#: trojsten/templates/search/search.html:32
 msgid "Title"
 msgstr "Názov"
 
-#: templates/search/search.html:33
+#: trojsten/templates/search/search.html:33
 msgid "Last modified"
 msgstr "Naposledy upravené"
 
-#: templates/search/search.html:58
+#: trojsten/templates/search/search.html:58
 msgid "There are no articles in this level"
 msgstr "Na tejto úrovni nie sú žiadne články."
 
-#: templates/search/search.html:68 templates/search/search.html:70
+#: trojsten/templates/search/search.html:68
+#: trojsten/templates/search/search.html:70
 msgid "Previous"
 msgstr "Predchádzajúca"
 
-#: templates/search/search.html:79 templates/search/search.html:81
+#: trojsten/templates/search/search.html:79
+#: trojsten/templates/search/search.html:81
 msgid "Next"
 msgstr "Nasledujúca"
 
-#: templates/wiki/article.html:19
+#: trojsten/templates/wiki/article.html:19
 msgid "locked"
 msgstr ""
 
-#: templates/wiki/article.html:40
+#: trojsten/templates/wiki/article.html:40
 msgid "This article was last modified:"
 msgstr "Čas poslednej úpravy:"
 

--- a/trojsten/submit/constants.py
+++ b/trojsten/submit/constants.py
@@ -13,6 +13,7 @@ SUBMIT_STATUS_CHOICES = [
     (SUBMIT_STATUS_FINISHED, _('finished')),
     (SUBMIT_STATUS_OK, _('OK')),  # for support of old interactive tasks
 ]
+SUBMIT_RESPONSE_PROTOCOL_CORRUPTED = 'PROTCOR'
 SUBMIT_RESPONSE_ERROR = 'CERR'
 SUBMIT_RESPONSE_OK = 'OK'
 SUBMIT_RAW_FILE_EXTENSION = '.raw'
@@ -37,7 +38,8 @@ SUBMIT_VERBOSE_RESPONSE = {
     'OK': _('OK'),
     'EXC': _('Runtime exception'),
     'SEC': _('Security exception'),
-    'IGN': _('Ignored')
+    'IGN': _('Ignored'),
+    'PROTCOR': _('Protocol corrupted'),
 }
 
 SUBMIT_PAPER_FILEPATH = '<PAPIEROVE>'

--- a/trojsten/submit/helpers.py
+++ b/trojsten/submit/helpers.py
@@ -4,6 +4,7 @@ import random
 import socket
 import xml.etree.ElementTree as ET
 from xml.etree.ElementTree import ParseError
+from xml.parsers.expat import ExpatError
 from decimal import Decimal
 from time import time
 
@@ -164,7 +165,7 @@ def parse_result_and_points_from_protocol(submit):
 
     try:
         tree = ET.parse(protocol_path)
-    except ParseError:
+    except (ParseError, ExpatError):
         return constants.SUBMIT_RESPONSE_PROTOCOL_CORRUPTED, 0
 
     # Ak kompilátor vyhlási chyby, testovač ich vráti v tagu <compileLog>

--- a/trojsten/submit/helpers.py
+++ b/trojsten/submit/helpers.py
@@ -3,8 +3,6 @@ import os
 import random
 import socket
 import xml.etree.ElementTree as ET
-from xml.etree.ElementTree import ParseError
-from xml.parsers.expat import ExpatError
 from decimal import Decimal
 from time import time
 
@@ -165,7 +163,7 @@ def parse_result_and_points_from_protocol(submit):
 
     try:
         tree = ET.parse(protocol_path)
-    except (ParseError, ExpatError):
+    except SyntaxError:
         return constants.SUBMIT_RESPONSE_PROTOCOL_CORRUPTED, 0
 
     # Ak kompilátor vyhlási chyby, testovač ich vráti v tagu <compileLog>

--- a/trojsten/submit/helpers.py
+++ b/trojsten/submit/helpers.py
@@ -3,6 +3,7 @@ import os
 import random
 import socket
 import xml.etree.ElementTree as ET
+from xml.etree.ElementTree import ParseError
 from decimal import Decimal
 from time import time
 
@@ -160,11 +161,10 @@ def parse_result_and_points_from_protocol(submit):
     protocol_path = submit.protocol_path
     if not os.path.exists(protocol_path):
         return None, None
-    print('AHA', protocol_path)
 
     try:
         tree = ET.parse(protocol_path)
-    except:  # noqa: E722 @FIXME
+    except ParseError:
         return constants.SUBMIT_RESPONSE_PROTOCOL_CORRUPTED, 0
 
     # Ak kompilátor vyhlási chyby, testovač ich vráti v tagu <compileLog>

--- a/trojsten/submit/helpers.py
+++ b/trojsten/submit/helpers.py
@@ -150,6 +150,52 @@ def process_submit(f, task, language, user):
     return process_submit_raw(f, contest_id, task.id, language, user.id)
 
 
+def parse_result_and_points_from_protocol(submit):
+    """
+    Z XML protokolu získa výsledok testovania a počet bodov,
+    ktoré sa neskôr môžu uložiť do databázy.
+
+    Ak protokol ešte neexistuje, vráti None, None.
+    """
+    protocol_path = submit.protocol_path
+    if not os.path.exists(protocol_path):
+        return None, None
+    print('AHA', protocol_path)
+
+    try:
+        tree = ET.parse(protocol_path)
+    except:  # noqa: E722 @FIXME
+        return constants.SUBMIT_RESPONSE_PROTOCOL_CORRUPTED, 0
+
+    # Ak kompilátor vyhlási chyby, testovač ich vráti v tagu <compileLog>
+    # Ak takýto tag existuje, výsledok je chyba pri testovaní a 0 bodov.
+    clog = tree.find("compileLog")
+    if clog is not None:
+        return constants.SUBMIT_RESPONSE_ERROR, 0
+
+    # Pre každý vstup kompilátor vyprodukuje tag <test>, všetky <test>-y
+    # sú v tag-u <runLog>. Výsledok je buď OK, alebo prvý nájdený druh
+    # chyby.
+    runlog = tree.find("runLog")
+    result = constants.SUBMIT_RESPONSE_OK
+    for test in runlog:
+        if test.tag != 'test':
+            continue
+        test_result = test[2].text
+        if test_result != constants.SUBMIT_RESPONSE_OK:
+            result = test_result
+            break
+    # Na konci testovača je v tagu <score> uložené percento získaných
+    # bodov.
+    try:
+        score = Decimal(tree.find("runLog/score").text)
+    except:  # noqa: E722 @FIXME
+        score = 0
+    points = (submit.task.source_points * score) / Decimal(100)
+
+    return result, points
+
+
 def update_submit(submit):
     """Zistí, či už je dotestované, ak hej, tak updatne databázu.
 
@@ -159,36 +205,9 @@ def update_submit(submit):
 
     Tento súbor obsahuje výstup testovača (v XML) a treba ho parse-núť
     """
-    protocol_path = submit.protocol_path
-    if os.path.exists(protocol_path):
-        tree = ET.parse(protocol_path)
-        # Ak kompilátor vyhlási chyby, testovač ich vráti v tagu <compileLog>
-        # Ak takýto tag existuje, výsledok je chyba pri testovaní a 0 bodov.
-        clog = tree.find("compileLog")
-        if clog is not None:
-            result = constants.SUBMIT_RESPONSE_ERROR
-            points = 0
-        else:
-            # Pre každý vstup kompilátor vyprodukuje tag <test>, všetky <test>-y
-            # sú v tag-u <runLog>. Výsledok je buď OK, alebo prvý nájdený druh
-            # chyby.
-            runlog = tree.find("runLog")
-            result = constants.SUBMIT_RESPONSE_OK
-            for test in runlog:
-                if test.tag != 'test':
-                    continue
-                test_result = test[2].text
-                if test_result != constants.SUBMIT_RESPONSE_OK:
-                    result = test_result
-                    break
-            # Na konci testovača je v tagu <score> uložené percento získaných
-            # bodov.
-            try:
-                score = Decimal(tree.find("runLog/score").text)
-            except:  # noqa: E722 @FIXME
-                score = 0
-            points = (submit.task.source_points * score) / Decimal(100)
-        submit.points = points
+    result, points = parse_result_and_points_from_protocol(submit)
+    if result is not None:
         submit.tester_response = result
+        submit.points = points
         submit.testing_status = constants.SUBMIT_STATUS_FINISHED
         submit.save()

--- a/trojsten/submit/test_data/corrupted_protocol.protokol
+++ b/trojsten/submit/test_data/corrupted_protocol.protokol
@@ -1,0 +1,6 @@
+<protokol<runLog>
+<test><name>0.sample.a.in</name><resultCode>1</resultCode><resultMsg>OK</resultMsg><time>28</time></test>
+<test><name>0.sample.b.in</name><resultCode>1</resultCode><resultMsg>OK</resultMsg><time>28</time></test>
+<score>100</score><details>
+Score: 100
+</details><finalResult>1</finalResult><finalMessage>OK (OK: 100 %)</finalMessage></runLog></protokol>

--- a/trojsten/submit/test_data/ok_protocol.protokol
+++ b/trojsten/submit/test_data/ok_protocol.protokol
@@ -1,0 +1,6 @@
+<protokol><runLog>
+<test><name>0.sample.a.in</name><resultCode>1</resultCode><resultMsg>OK</resultMsg><time>28</time></test>
+<test><name>0.sample.b.in</name><resultCode>1</resultCode><resultMsg>OK</resultMsg><time>28</time></test>
+<score>100</score><details>
+Score: 100
+</details><finalResult>1</finalResult><finalMessage>OK (OK: 100 %)</finalMessage></runLog></protokol>

--- a/trojsten/submit/tests.py
+++ b/trojsten/submit/tests.py
@@ -25,7 +25,8 @@ from trojsten.people.models import User
 from trojsten.submit import constants
 from trojsten.submit.forms import SubmitAdminForm
 from trojsten.submit.helpers import (get_lang_from_filename, get_path_raw,
-                                     post_submit, write_chunks_to_file, get_description_file_path)
+                                     post_submit, write_chunks_to_file, get_description_file_path,
+                                     update_submit)
 from trojsten.utils.test_utils import get_noexisting_id
 from .models import ExternalSubmitToken, Submit
 
@@ -458,6 +459,17 @@ class SubmitHelpersTests(TestCase):
     def setUp(self):
         self.temp_dir = tempfile.mkdtemp()
 
+        self.user = User.objects.create_user(username='jozko', first_name='Jozko',
+                                             last_name='Mrkvicka', password='pass',
+                                             graduation=timezone.now().year + 1)
+        competition = Competition.objects.create(name='TestCompetition')
+        semester = Semester.objects.create(
+            number=1, name='Test semester', competition=competition, year=1)
+        round = Round.objects.create(number=1, semester=semester,
+                                     start_time=timezone.now(), end_time=timezone.now())
+        self.task = Task.objects.create(number=1, name='Test task', round=round,
+                                        has_source=True, source_points=20)
+
     def tearDown(self):
         shutil.rmtree(self.temp_dir)
 
@@ -501,6 +513,34 @@ class SubmitHelpersTests(TestCase):
         post_submit(u'raw', b'data')
         server_thread.join()
         self.assertEqual(self.received, b'rawdata')
+
+    def test_update_submit_ok(self):
+        submit = Submit.objects.create(
+            task=self.task, user=self.user, submit_type=constants.SUBMIT_TYPE_SOURCE,
+            points=0, testing_status=constants.SUBMIT_STATUS_IN_QUEUE,
+            # the extension will be automatically changed to .protokol when searching for protocol
+            filepath=path.join('trojsten', 'submit', 'test_data', 'ok_protocol.data')
+        )
+
+        update_submit(submit)
+
+        self.assertEqual(submit.testing_status, constants.SUBMIT_STATUS_FINISHED)
+        self.assertEqual(submit.tester_response, constants.SUBMIT_RESPONSE_OK)
+        self.assertEqual(submit.points, 20)
+
+    def test_update_submit_corrupted_protocol(self):
+        submit = Submit.objects.create(
+            task=self.task, user=self.user, submit_type=constants.SUBMIT_TYPE_SOURCE,
+            points=0, testing_status=constants.SUBMIT_STATUS_IN_QUEUE,
+            # the extension will be automatically changed to .protokol when searching for protocol
+            filepath=path.join('trojsten', 'submit', 'test_data', 'corrupted_protocol.data')
+        )
+
+        update_submit(submit)
+
+        self.assertEqual(submit.testing_status, constants.SUBMIT_STATUS_FINISHED)
+        self.assertEqual(submit.tester_response, constants.SUBMIT_RESPONSE_PROTOCOL_CORRUPTED)
+        self.assertEqual(submit.points, 0)
 
 
 class ExternalSubmitKeyTests(TestCase):

--- a/trojsten/submit/views.py
+++ b/trojsten/submit/views.py
@@ -4,6 +4,7 @@
 import json
 import os
 import xml.etree.ElementTree as ET
+from xml.etree.ElementTree import ParseError
 
 import six
 from django.conf import settings
@@ -39,9 +40,9 @@ def protocol_data(protocol_path, force_show_details=False):
         template_data['protocolReady'] = True  # Tested, show the protocol
         try:
             tree = ET.parse(protocol_path)  # Protocol is in XML format
-        except:  # noqa: E722 @FIXME
-            # don't throw error if protocol is corrupted. (should only happen
-            # while protocol is being uploaded)
+        except ParseError:
+            # Don't throw error if protocol is corrupted: either protocol is still being uploaded
+            # or the user is informed about the corrupted protocol via submit response status.
             template_data['protocolReady'] = False
             return template_data
         clog = tree.find('compileLog')

--- a/trojsten/submit/views.py
+++ b/trojsten/submit/views.py
@@ -4,8 +4,6 @@
 import json
 import os
 import xml.etree.ElementTree as ET
-from xml.etree.ElementTree import ParseError
-from xml.parsers.expat import ExpatError
 
 import six
 from django.conf import settings
@@ -41,7 +39,7 @@ def protocol_data(protocol_path, force_show_details=False):
         template_data['protocolReady'] = True  # Tested, show the protocol
         try:
             tree = ET.parse(protocol_path)  # Protocol is in XML format
-        except (ParseError, ExpatError):
+        except SyntaxError:
             # Don't throw error if protocol is corrupted: either protocol is still being uploaded
             # or the user is informed about the corrupted protocol via submit response status.
             template_data['protocolReady'] = False

--- a/trojsten/submit/views.py
+++ b/trojsten/submit/views.py
@@ -287,6 +287,10 @@ def poll_submit_info(request, submit_id):
             task__round__semester__competition__organizers_group__user__pk=request.user.pk).exists():
         # You shouldn't see other user's submits if you are not an organizer of the competition
         raise PermissionDenied()
+
+    if not submit.tested:  # try to find and parse protocol with each poll
+        update_submit(submit)
+
     return HttpResponse(json.dumps({
         'tested': submit.tested,
         'response_verbose': six.text_type(submit.tester_response_verbose),

--- a/trojsten/submit/views.py
+++ b/trojsten/submit/views.py
@@ -5,6 +5,7 @@ import json
 import os
 import xml.etree.ElementTree as ET
 from xml.etree.ElementTree import ParseError
+from xml.parsers.expat import ExpatError
 
 import six
 from django.conf import settings
@@ -40,7 +41,7 @@ def protocol_data(protocol_path, force_show_details=False):
         template_data['protocolReady'] = True  # Tested, show the protocol
         try:
             tree = ET.parse(protocol_path)  # Protocol is in XML format
-        except ParseError:
+        except (ParseError, ExpatError):
             # Don't throw error if protocol is corrupted: either protocol is still being uploaded
             # or the user is informed about the corrupted protocol via submit response status.
             template_data['protocolReady'] = False


### PR DESCRIPTION
Closes #1103 
Vždy keď sa testovač pozerá, či už má výsledok, skontroluje nie len databázu, ale aj či náhodou nedostal súbor od testovača.

Closes #1153
Closes #917 
Keď sa pri prijatí protokolu od testovača nepodarí prečítať protokol, označí sa ako corrupted (doteraz posielal server error a zostával ako nedotestovaný).

Občas môže stať, že sa server pri pollovaní bude snažiť čítať nie úplne skopírovaný protokol a označí ho za corrupted, ale asi je to lepšie ako vyťažovať KSP server stále sa točiacimi kolieskami, že "čaká sa na odpoveď testovača", keď odpoveď už aj tak nikdy nepríde.

