### PR TITLE
Refactor submit

### DIFF
--- a/trojsten/settings/common.py
+++ b/trojsten/settings/common.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 # Common settings for trojsten.
-import json
-import os
 import sys
 
+import json
+import os
 from django.contrib.messages import constants as messages
 from django.http import UnreadablePostError
 from django.utils.translation import ugettext_lazy as _
 
 import trojsten.special.installed_apps
+from trojsten.submit import judge_client
 from . import site_config
 
 
@@ -506,6 +507,8 @@ PROTOCOL_FILE_EXTENSION = env('TROJSTENWEB_PROTOCOL_FILE_EXTENSION', '.protokol'
 TESTER_URL = env('TROJSTENWEB_TESTER_URL', 'experiment')
 TESTER_PORT = int(env('TROJSTENWEB_TESTER_PORT', '12347'))
 TESTER_WEB_IDENTIFIER = env('TROJSTENWEB_TESTER_WEB_IDENTIFIER', 'KSP')
+JUDGE_CLIENT = judge_client.JudgeClient(TESTER_WEB_IDENTIFIER, TESTER_URL, TESTER_PORT)
+
 
 # Rules settings
 COMPETITION_RULES = {

--- a/trojsten/settings/development.py
+++ b/trojsten/settings/development.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+
 import os
 
 from trojsten.settings.common import *
@@ -104,3 +105,5 @@ SOCIAL_AUTH_TROJSTEN_SECRET = env(
 )
 
 ELASTICSEARCH_TESTS = bool(int(env('TROJSTENWEB_ELASTICSEARCH_TESTS', False)))
+JUDGE_CLIENT = judge_client.DebugJudgeClient()
+

--- a/trojsten/submit/constants.py
+++ b/trojsten/submit/constants.py
@@ -43,3 +43,18 @@ SUBMIT_VERBOSE_RESPONSE = {
 }
 
 SUBMIT_PAPER_FILEPATH = '<PAPIEROVE>'
+
+EXT_MAPPING = {
+    ".cpp": ".cc",
+    ".cc": ".cc",
+    ".pp": ".pas",
+    ".pas": ".pas",
+    ".dpr": ".pas",
+    ".c": ".c",
+    ".py": ".py",
+    ".py3": ".py",
+    ".hs": ".hs",
+    ".cs": ".cs",
+    ".java": ".java",
+    ".zip": ".zip",
+}

--- a/trojsten/submit/helpers.py
+++ b/trojsten/submit/helpers.py
@@ -76,7 +76,7 @@ def process_submit(f, task, language, user):
     submit_id = _generate_submit_id()
     user_id = "%s-%d" % (contest_id, user.id)
     task_id = "%s-%d" % (contest_id, task.id)
-    data = smart_bytes(f.read())
+    data = f.read()
 
     judge_client.submit(submit_id, user_id, task_id, data, language)
 

--- a/trojsten/submit/helpers.py
+++ b/trojsten/submit/helpers.py
@@ -1,17 +1,17 @@
 # -*- coding: utf-8 -*-
-import os
-import random
-import socket
-import xml.etree.ElementTree as ET
-from decimal import Decimal
 from time import time
 
+import os
+import xml.etree.ElementTree as ET
+from decimal import Decimal
 from django.conf import settings
 from django.utils.encoding import smart_bytes
 from os import path
 from unidecode import unidecode
 
 from . import constants
+
+judge_client = settings.JUDGE_CLIENT
 
 
 def write_chunks_to_file(filepath, chunks):
@@ -85,22 +85,10 @@ def get_description_file_path(file, user, task):
     ))
 
 
-def post_submit(raw, data):
-    """Pošle RAW na otestovanie"""
-    if settings.SUBMIT_DEBUG:
-        print("Submit RAW: ")
-        print(raw)
-        print(data)
-    else:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.connect((settings.TESTER_URL, settings.TESTER_PORT))
-        sock.sendall(smart_bytes(raw))
-        sock.sendall(smart_bytes(data))
-        sock.close()
+def process_submit(f, task, language, user):
+    """Načíta všetko potrebné z databázy a spracuje submit"""
+    contest_id = task.round.semester.competition.name
 
-
-def process_submit_raw(f, contest_id, task_id, language, user_id):
-    """Spracuje submit bez dotknutia databázy"""
     # Determine language from filename if language not entered
     if language == '.':
         language = get_lang_from_filename(f.name)
@@ -108,46 +96,20 @@ def process_submit_raw(f, contest_id, task_id, language, user_id):
             return False
 
     language = language.strip('.')
+    data = smart_bytes(f.read())
+    user_id = "%s-%d" % (contest_id, user.id)
+    task_id = "%s-%d" % (contest_id, task.id)
 
-    # Generate submit ID
-    # Submit ID is <timestamp>-##### where ##### are 5 random digits
-    timestamp = int(time())
-    submit_id = "%d-%05d" % (timestamp, random.randint(0, 99999))
-
-    # Prepare submit parameters (not entirely sure about this yet).
-    user_id = "%s-%d" % (contest_id, user_id)
-    task_id = "%s-%d" % (contest_id, task_id)
-    data = f.read()
+    submit_id = judge_client.submit(user_id, task_id, data, language)
 
     # Determine local directory to store RAW file into
-    path = get_path_raw(contest_id, task_id, user_id)
-
-    priority = 0
-
-    # Prepare RAW header from submit parameters
-    raw = "submit1.3\n%s\n%s\n%s\n%s\n%s\n%s\nmagic_footer\n" % (
-        settings.TESTER_WEB_IDENTIFIER,
-        submit_id,
-        user_id,
-        task_id,
-        language,
-        priority,
-    )
+    submission_directory = get_path_raw(contest_id, task_id, user_id)
 
     # Write RAW to local file
-    write_chunks_to_file(os.path.join(path, submit_id + constants.SUBMIT_RAW_FILE_EXTENSION), [raw, data])
-
-    # Send RAW for testing (uncomment when deploying)
-    post_submit(raw, data)
+    write_chunks_to_file(os.path.join(submission_directory, submit_id + constants.SUBMIT_RAW_FILE_EXTENSION), [raw, data])
 
     # Return submit ID
     return submit_id
-
-
-def process_submit(f, task, language, user):
-    """Načíta všetko potrebné z databázy a spracuje submit"""
-    contest_id = task.round.semester.competition.name
-    return process_submit_raw(f, contest_id, task.id, language, user.id)
 
 
 def parse_result_and_points_from_protocol(submit):

--- a/trojsten/submit/helpers.py
+++ b/trojsten/submit/helpers.py
@@ -15,7 +15,11 @@ judge_client = settings.JUDGE_CLIENT
 
 
 def write_chunks_to_file(target_path, chunks):
-    os.makedirs(os.path.dirname(target_path))
+    try:
+        os.makedirs(os.path.dirname(target_path))
+    except OSError:
+        # Directory exists.
+        pass
     with open(target_path, 'wb+') as destination:
         for chunk in chunks:
             destination.write(smart_bytes(chunk))

--- a/trojsten/submit/helpers.py
+++ b/trojsten/submit/helpers.py
@@ -96,8 +96,9 @@ def parse_result_and_points_from_protocol(submit):
 
     with open(protocol_path) as protocol:
         try:
-            return judge_client.parse_protocol(protocol, max_points=submit.task.source_points)
-        except ProtocolCorruptedError:
+            # TODO: limit protocol size so we don't go OOM in case of malicious protocol.
+            return judge_client.parse_protocol(protocol.read(), max_points=submit.task.source_points)
+        except ProtocolCorruptedError as e:
             return constants.SUBMIT_RESPONSE_PROTOCOL_CORRUPTED, 0
 
 

--- a/trojsten/submit/judge_client.py
+++ b/trojsten/submit/judge_client.py
@@ -21,7 +21,7 @@ class JudgeClient(object):
         self.tester_url = tester_url
         self.tester_port = tester_port
 
-    def submit(self, submit_id, user_id, task_id, submission_content, language):
+    def submit(self, submit_id, user_id, task_id, submission_content, language, priority=0):
         """Submits a file to the judge system.
 
         :param submit_id: unique id of the submit.
@@ -32,7 +32,7 @@ class JudgeClient(object):
         :returns: submit_id
         """
 
-        header = self._create_header(submit_id, user_id, task_id, language)
+        header = self._create_header(submit_id, user_id, task_id, language, priority)
         self._send_data_to_server(header, submission_content)
 
     @staticmethod
@@ -74,7 +74,7 @@ class JudgeClient(object):
 
         return result, points
 
-    def _create_header(self, submit_id, user_id, task_id, language):
+    def _create_header(self, submit_id, user_id, task_id, language, priority):
         """Creates a raw header from submit parameters"""
         return 'submit1.3\n%s\n%s\n%s\n%s\n%s\n%s\nmagic_footer\n' % (
             self.tester_id,
@@ -82,7 +82,7 @@ class JudgeClient(object):
             user_id,
             task_id,
             language,
-            0,  # priority
+            priority,
         )
 
     def _send_data_to_server(self, header, submission_file_content):

--- a/trojsten/submit/judge_client.py
+++ b/trojsten/submit/judge_client.py
@@ -1,0 +1,72 @@
+from time import time
+
+import random
+import socket
+from django.utils.encoding import smart_bytes
+
+
+class JudgeClient(object):
+
+    def __init__(self, tester_id, tester_url, tester_port):
+        """Initializes JudgeClient instance.
+
+        :param tester_id:
+        :param tester_url:
+        :param tester_port:
+        :param storage:
+        """
+        self.tester_id = tester_id
+        self.tester_url = tester_url
+        self.tester_port = tester_port
+
+    def submit(self, user_id, task_id, submission_content, language):
+        """Submits a file to the judge system.
+
+        :param user_id: user id for the judge system in form of contestid-userid.
+        :param task_id: task id for the judge system in form of contestid-taskid.
+        :param submission_content: submission file content uploaded by user.
+        :param language: programming language for the submission_file.
+        :returns: submit_id
+        """
+
+        submit_id = JudgeClient._generate_submit_id()
+        header = self._create_header(submit_id, user_id, task_id, language)
+        self._send_data_to_server(header, submission_content)
+
+        return submit_id
+
+    @staticmethod
+    def _generate_submit_id():
+        """Generates a submit id in form of <timestamp>-##### where ##### are 5 random digits."""
+        timestamp = int(time())
+        return '%d-%05d' % (timestamp, random.randint(0, 99999))
+
+    def _create_header(self, submit_id, user_id, task_id, language):
+        """Creates a raw header from submit parameters"""
+        return smart_bytes('submit1.3\n%s\n%s\n%s\n%s\n%s\n%s\nmagic_footer\n' % (
+            self.tester_id,
+            submit_id,
+            user_id,
+            task_id,
+            language,
+            0,  # priority
+        ))
+
+    def _send_data_to_server(self, header, submission_file_content):
+        """Sends submission to the judge system."""
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.connect((self.tester_url, self.tester_port))
+        sock.sendall(header)
+        sock.sendall(submission_file_content)
+        sock.close()
+
+
+class DebugJudgeClient(JudgeClient):
+    def __init__(self):
+        super(DebugJudgeClient, self).__init__('TEST_ID', 'TEST_URL', 47)
+
+    def _send_data_to_server(self, header, submission_file_content):
+        print('Submit RAW:')
+        print(header)
+        print(submission_file_content)
+

--- a/trojsten/submit/judge_client.py
+++ b/trojsten/submit/judge_client.py
@@ -1,9 +1,10 @@
+# coding=utf-8
 import socket
+from decimal import Decimal
 from django.utils.encoding import smart_bytes
+from xlrd.xlsx import ET
 
-
-class JudgeConnectionError(IOError):
-    pass
+from trojsten.submit import constants
 
 
 class JudgeClient(object):
@@ -33,6 +34,44 @@ class JudgeClient(object):
 
         header = self._create_header(submit_id, user_id, task_id, language)
         self._send_data_to_server(header, submission_content)
+
+    @staticmethod
+    def parse_protocol(protocol_content, max_points):
+        """Parses protocol returned by judge system.
+
+        If protocol contains <compileLog> it means there was a testing error.
+        If any of <test> tag in <runLog> contains non OK result, the overall result is the first non OK result.
+        The points are computed from percentage of maximum points stored in <score> tag.
+
+        :param protocol_content: content of the protocol.
+        :param max_points: maximum possible points for the task.
+        :return: testing_result, number_of_points
+        """
+        try:
+            tree = ET.parse(protocol_content)
+        except SyntaxError:
+            raise ProtocolCorruptedError('Error while parsing protocol.\n%s' % protocol_content)
+
+        compile_log = tree.find("compileLog")
+        if compile_log is not None:
+            return constants.SUBMIT_RESPONSE_ERROR, 0  # Returns zero points if there was error.
+
+        run_log = tree.find("runLog")
+        result = constants.SUBMIT_RESPONSE_OK
+        for test in run_log:
+            if test.tag != 'test':
+                continue
+            test_result = test[2].text
+            if test_result != constants.SUBMIT_RESPONSE_OK:
+                result = test_result
+                break
+        try:
+            score = Decimal(tree.find("runLog/score").text)
+        except (ValueError, TypeError):
+            raise ProtocolFormatError("Invalid score.\n%s" % protocol_content)
+        points = (max_points * score) / Decimal(100)
+
+        return result, points
 
     def _create_header(self, submit_id, user_id, task_id, language):
         """Creates a raw header from submit parameters"""
@@ -66,3 +105,19 @@ class DebugJudgeClient(JudgeClient):
         print('Submit RAW:')
         print(header)
         print(submission_file_content)
+
+
+class JudgeConnectionError(IOError):
+    pass
+
+
+class ProtocolError(ValueError):
+    pass
+
+
+class ProtocolCorruptedError(ProtocolError):
+    pass
+
+
+class ProtocolFormatError(ProtocolError):
+    pass

--- a/trojsten/submit/judge_client.py
+++ b/trojsten/submit/judge_client.py
@@ -80,22 +80,22 @@ class JudgeClient(object):
 
     def _create_header(self, submit_id, user_id, task_id, language):
         """Creates a raw header from submit parameters"""
-        return smart_bytes('submit1.3\n%s\n%s\n%s\n%s\n%s\n%s\nmagic_footer\n' % (
+        return 'submit1.3\n%s\n%s\n%s\n%s\n%s\n%s\nmagic_footer\n' % (
             self.tester_id,
             submit_id,
             user_id,
             task_id,
             language,
             0,  # priority
-        ))
+        )
 
     def _send_data_to_server(self, header, submission_file_content):
         """Sends submission to the judge system."""
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             sock.connect((self.tester_url, self.tester_port))
-            sock.sendall(header)
-            sock.sendall(submission_file_content)
+            sock.sendall(smart_bytes(header))
+            sock.sendall(smart_bytes(submission_file_content))
         except JudgeConnectionError:
             raise JudgeConnectionError(
                 'Failed to connect to judge system (%s:%s)' % (self.tester_url, self.tester_port))

--- a/trojsten/submit/test_judge_client.py
+++ b/trojsten/submit/test_judge_client.py
@@ -13,9 +13,6 @@ class SubmitHelpersTests(TestCase):
     TESTER_ID = 'TEST'
 
     def setUp(self):
-        self.judge_client = JudgeClient(self.TESTER_ID, self.TESTER_URL, self.TESTER_PORT)
-
-    def test_submit(self):
         def run_fake_server(test):
             server_sock = socket.socket()
             server_sock.bind((self.TESTER_URL, self.TESTER_PORT))
@@ -26,11 +23,14 @@ class SubmitHelpersTests(TestCase):
             server_sock.close()
             test.received = raw + data
 
-        server_thread = threading.Thread(target=run_fake_server, args=(self,))
-        server_thread.start()
+        self.judge_client = JudgeClient(self.TESTER_ID, self.TESTER_URL, self.TESTER_PORT)
+        self.server_thread = threading.Thread(target=run_fake_server, args=(self,))
+        self.server_thread.start()
         time.sleep(50.0 / 1000.0)  # 50ms should be enough for the server to bind
+
+    def test_submit(self):
         self.judge_client.submit('test_id', 'test_user', 'test_task', 'test_submission', 'py')
-        server_thread.join()
+        self.server_thread.join()
 
         request_parts = self.received.split(b'\n')
         # Header
@@ -41,6 +41,23 @@ class SubmitHelpersTests(TestCase):
         self.assertEqual(request_parts[4], b'test_task')
         self.assertEqual(request_parts[5], b'py')
         self.assertEqual(request_parts[6], b'0')
+        self.assertEqual(request_parts[7], b'magic_footer')
+        # Submission
+        self.assertEqual(request_parts[8], b'test_submission')
+
+    def test_submit_with_priority(self):
+        self.judge_client.submit('test_id', 'test_user', 'test_task', 'test_submission', 'py', 1)
+        self.server_thread.join()
+
+        request_parts = self.received.split(b'\n')
+        # Header
+        self.assertEqual(request_parts[0], b'submit1.3')
+        self.assertEqual(request_parts[1], b'TEST')
+        self.assertEqual(request_parts[2], b'test_id')
+        self.assertEqual(request_parts[3], b'test_user')
+        self.assertEqual(request_parts[4], b'test_task')
+        self.assertEqual(request_parts[5], b'py')
+        self.assertEqual(request_parts[6], b'1')
         self.assertEqual(request_parts[7], b'magic_footer')
         # Submission
         self.assertEqual(request_parts[8], b'test_submission')

--- a/trojsten/submit/test_judge_client.py
+++ b/trojsten/submit/test_judge_client.py
@@ -29,14 +29,14 @@ class SubmitHelpersTests(TestCase):
         server_thread = threading.Thread(target=run_fake_server, args=(self,))
         server_thread.start()
         time.sleep(50.0 / 1000.0)  # 50ms should be enough for the server to bind
-        self.judge_client.submit('test_user', 'test_task', 'test_submission', 'py')
+        self.judge_client.submit('test_id', 'test_user', 'test_task', 'test_submission', 'py')
         server_thread.join()
 
         request_parts = self.received.split('\n')
         # Header
         self.assertEqual(request_parts[0], b'submit1.3')
         self.assertEqual(request_parts[1], b'TEST')
-        self.assertEqual(len(request_parts[2]), 16)
+        self.assertEqual(request_parts[2], b'test_id')
         self.assertEqual(request_parts[3], b'test_user')
         self.assertEqual(request_parts[4], b'test_task')
         self.assertEqual(request_parts[5], b'py')

--- a/trojsten/submit/test_judge_client.py
+++ b/trojsten/submit/test_judge_client.py
@@ -44,4 +44,3 @@ class SubmitHelpersTests(TestCase):
         self.assertEqual(request_parts[7], b'magic_footer')
         # Submission
         self.assertEqual(request_parts[8], b'test_submission')
-

--- a/trojsten/submit/test_judge_client.py
+++ b/trojsten/submit/test_judge_client.py
@@ -1,0 +1,47 @@
+import time
+
+import socket
+import threading
+from unittest import TestCase
+
+from trojsten.submit.judge_client import JudgeClient
+
+
+class SubmitHelpersTests(TestCase):
+    TESTER_URL = '127.0.0.1'
+    TESTER_PORT = 7777
+    TESTER_ID = 'TEST'
+
+    def setUp(self):
+        self.judge_client = JudgeClient(self.TESTER_ID, self.TESTER_URL, self.TESTER_PORT)
+
+    def test_submit(self):
+        def run_fake_server(test):
+            server_sock = socket.socket()
+            server_sock.bind((self.TESTER_URL, self.TESTER_PORT))
+            server_sock.listen(0)
+            conn, addr = server_sock.accept()
+            raw = conn.recv(2048)
+            data = conn.recv(2048)
+            server_sock.close()
+            test.received = raw + data
+
+        server_thread = threading.Thread(target=run_fake_server, args=(self,))
+        server_thread.start()
+        time.sleep(50.0 / 1000.0)  # 50ms should be enough for the server to bind
+        self.judge_client.submit('test_user', 'test_task', 'test_submission', 'py')
+        server_thread.join()
+
+        request_parts = self.received.split('\n')
+        # Header
+        self.assertEqual(request_parts[0], b'submit1.3')
+        self.assertEqual(request_parts[1], b'TEST')
+        self.assertEqual(len(request_parts[2]), 16)
+        self.assertEqual(request_parts[3], b'test_user')
+        self.assertEqual(request_parts[4], b'test_task')
+        self.assertEqual(request_parts[5], b'py')
+        self.assertEqual(request_parts[6], b'0')
+        self.assertEqual(request_parts[7], b'magic_footer')
+        # Submission
+        self.assertEqual(request_parts[8], b'test_submission')
+

--- a/trojsten/submit/test_judge_client.py
+++ b/trojsten/submit/test_judge_client.py
@@ -32,7 +32,7 @@ class SubmitHelpersTests(TestCase):
         self.judge_client.submit('test_id', 'test_user', 'test_task', 'test_submission', 'py')
         server_thread.join()
 
-        request_parts = self.received.split('\n')
+        request_parts = self.received.split(b'\n')
         # Header
         self.assertEqual(request_parts[0], b'submit1.3')
         self.assertEqual(request_parts[1], b'TEST')

--- a/trojsten/submit/tests.py
+++ b/trojsten/submit/tests.py
@@ -4,13 +4,8 @@ from __future__ import unicode_literals
 import json
 import os
 import shutil
-import socket
 import tempfile
-import threading
-import time
 import unittest
-from os import path
-
 from django.conf import settings
 from django.contrib.auth.models import Group
 from django.contrib.sites.models import Site
@@ -20,14 +15,15 @@ from django.core.urlresolvers import reverse
 from django.test import TestCase, override_settings
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
+from os import path
 
-from trojsten.contests.models import Competition, Round, Semester, Task, TaskPeople
 from trojsten.contests.constants import TASK_ROLE_REVIEWER
+from trojsten.contests.models import Competition, Round, Semester, Task, TaskPeople
 from trojsten.people.models import User
 from trojsten.submit import constants
 from trojsten.submit.forms import SubmitAdminForm
 from trojsten.submit.helpers import (get_lang_from_filename, get_path_raw,
-                                     post_submit, write_chunks_to_file, get_description_file_path,
+                                     write_chunks_to_file, get_description_file_path,
                                      update_submit)
 from trojsten.submit.views import send_notification_email
 from trojsten.utils.test_utils import get_noexisting_id
@@ -493,29 +489,6 @@ class SubmitHelpersTests(TestCase):
     def test_get_path_raw(self):
         self.assertEqual(get_path_raw('contest', 'task', 'user'),
                          os.path.join(settings.SUBMIT_PATH, 'submits', 'user', 'task'))
-
-    @override_settings(
-        TESTER_URL='127.0.0.1',
-        TESTER_PORT=7777,
-        SUBMIT_DEBUG=False,
-    )
-    def test_post_submit(self):
-        def run_fake_server(test):
-            server_sock = socket.socket()
-            server_sock.bind((settings.TESTER_URL, settings.TESTER_PORT))
-            server_sock.listen(0)
-            conn, addr = server_sock.accept()
-            raw = conn.recv(2048)
-            data = conn.recv(2048)
-            server_sock.close()
-            test.received = raw + data
-
-        server_thread = threading.Thread(target=run_fake_server, args=(self,))
-        server_thread.start()
-        time.sleep(50.0 / 1000.0)  # 50ms should be enough for the server to bind
-        post_submit(u'raw', b'data')
-        server_thread.join()
-        self.assertEqual(self.received, b'rawdata')
 
     def test_update_submit_ok(self):
         submit = Submit.objects.create(

--- a/trojsten/submit/tests.py
+++ b/trojsten/submit/tests.py
@@ -22,9 +22,9 @@ from trojsten.contests.models import Competition, Round, Semester, Task, TaskPeo
 from trojsten.people.models import User
 from trojsten.submit import constants
 from trojsten.submit.forms import SubmitAdminForm
-from trojsten.submit.helpers import (get_lang_from_filename, get_path_raw,
+from trojsten.submit.helpers import (get_lang_from_filename,
                                      write_chunks_to_file, get_description_file_path,
-                                     update_submit)
+                                     update_submit, get_path)
 from trojsten.submit.views import send_notification_email
 from trojsten.utils.test_utils import get_noexisting_id
 from .models import ExternalSubmitToken, Submit
@@ -486,9 +486,12 @@ class SubmitHelpersTests(TestCase):
         self.assertEqual(get_lang_from_filename('file.cpp'), '.cc')
         self.assertEqual(get_lang_from_filename('file.foo'), False)
 
-    def test_get_path_raw(self):
-        self.assertEqual(get_path_raw('contest', 'task', 'user'),
-                         os.path.join(settings.SUBMIT_PATH, 'submits', 'user', 'task'))
+    def test_get_path(self):
+        contest = self.task.round.semester.competition.name
+        tester_user_id = '%s-%s' % (contest, self.user.id)
+        tester_task_id = '%s-%s' % (contest, self.task.id)
+        self.assertEqual(get_path(self.task, self.user),
+                         os.path.join(settings.SUBMIT_PATH, 'submits', tester_user_id, tester_task_id))
 
     def test_update_submit_ok(self):
         submit = Submit.objects.create(

--- a/trojsten/submit/tests.py
+++ b/trojsten/submit/tests.py
@@ -22,7 +22,7 @@ from trojsten.contests.models import Competition, Round, Semester, Task, TaskPeo
 from trojsten.people.models import User
 from trojsten.submit import constants
 from trojsten.submit.forms import SubmitAdminForm
-from trojsten.submit.helpers import (get_lang_from_filename,
+from trojsten.submit.helpers import (_get_lang_from_filename,
                                      write_chunks_to_file, get_description_file_path,
                                      update_submit, get_path)
 from trojsten.submit.views import send_notification_email
@@ -483,8 +483,8 @@ class SubmitHelpersTests(TestCase):
             self.assertEqual(data, b'helloworld')
 
     def test_get_lang_from_filename(self):
-        self.assertEqual(get_lang_from_filename('file.cpp'), '.cc')
-        self.assertEqual(get_lang_from_filename('file.foo'), False)
+        self.assertEqual(_get_lang_from_filename('file.cpp'), '.cc')
+        self.assertEqual(_get_lang_from_filename('file.foo'), None)
 
     def test_get_path(self):
         contest = self.task.round.semester.competition.name


### PR DESCRIPTION
Logika ktora sa tyka cisto testovaca sa presunula do JudgeClient.
JudgeClient sa da casom extrahovat a pouzit v inych sutaziach na kumunikaciu s testovacom, pripadne pri zachovani api sa da jednoducho vymenit ak sa zmenni testovac.

Jedina breaking zmena, raw sa uz neuklada do filesystemu. Aj tak nam na nic nie je.
