### PR TITLE
Use correct school year in results serialization.

### DIFF
--- a/trojsten/results/representation.py
+++ b/trojsten/results/representation.py
@@ -70,7 +70,7 @@ class ResultsRow(Serializable):
             'username': self.user.username,
             'name': self.user.get_full_name(),
             'school': self._serialize_school_data(),
-            'year': self.user.school_year,
+            'year': self.year,
         }
 
     def _serialize_school_data(self):

--- a/trojsten/results/tests.py
+++ b/trojsten/results/tests.py
@@ -245,7 +245,7 @@ class ResultsTest(TestCase):
         response = self.client.get("%s?single_round=True" % self.url2)
         self.assertContains(response, self.user.get_full_name())
 
-    def test_two_years(self):
+    def test_use_correct_year_in_old_results(self):
         submit_time = self.round0.start_time + timezone.timedelta(0, 5)
         submit = Submit.objects.create(task=self.task0, user=self.user, submit_type=0, points=9)
         submit.time = submit_time


### PR DESCRIPTION
Do serializácie userov sa dával zlý ročník, čo spôsobovalo, že ročníky zo starých výsledkoviek sa s novým rokom zvyšovali.

Zišiel by sa k tomu aj test, ktorý by toto checkoval, len neviem, kedy sa k tomu dostanem.