### PR TITLE
Fix db sanitizer

### DIFF
--- a/requirements.devel.txt
+++ b/requirements.devel.txt
@@ -59,13 +59,13 @@ elasticsearch==6.3.1
 enum34==1.1.6             # via cryptography
 et-xmlfile==1.0.1         # via openpyxl
 fabric==2.4.0
-fake-factory==9999.9.9
+faker==0.9.2
 first==2.0.1
 html5lib==0.9999999       # via bleach
 idna==2.7                 # via cryptography
 importlib==1.0.4
 invoke==1.2.0             # via fabric
-ipaddress==1.0.22         # via cryptography
+ipaddress==1.0.22         # via cryptography, faker
 jdcal==1.4                # via openpyxl
 kombu==3.0.37             # via celery
 ksp-login==0.5.0
@@ -85,17 +85,19 @@ pymdown-extensions==2.0
 pynacl==1.3.0             # via paramiko
 pyopenssl==18.0.0         # via ndg-httpsclient
 python-akismet==0.4.1     # via django-fluent-comments
+python-dateutil==2.7.5    # via faker
 python-openid==2.2.5      # via social-auth-core
 pytz==2018.5
 pyyaml==3.13              # via tablib
 requests-oauthlib==1.0.0  # via social-auth-core
 requests==2.14.2
-six==1.11.0               # via bcrypt, bleach, cryptography, django-nyt, html5lib, pip-tools, pynacl, pyopenssl, social-auth-app-django, social-auth-core, trojsten-judge-client, wiki
+six==1.11.0               # via bcrypt, bleach, cryptography, django-nyt, faker, html5lib, pip-tools, pynacl, pyopenssl, python-dateutil, social-auth-app-django, social-auth-core, trojsten-judge-client, wiki
 social-auth-app-django==1.2.0
 social-auth-core==1.7.0   # via ksp-login, social-auth-app-django
 sorl-thumbnail==12.5.0    # via wiki
 sqlparse==0.2.4
 tablib==0.12.1            # via django-import-export
+text-unidecode==1.2       # via faker
 trojsten-judge-client==1.0.1
 unicodecsv==0.14.1        # via tablib
 unidecode==1.0.22

--- a/requirements.in
+++ b/requirements.in
@@ -31,7 +31,7 @@ Django>=1.11,<2
 djangorestframework
 ecdsa
 elasticsearch
-fake-factory
+Faker
 first
 ksp-login>=0.5
 psycopg2>=2.7.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,12 +53,12 @@ ecdsa==0.13
 elasticsearch==6.3.1
 enum34==1.1.6             # via cryptography
 et-xmlfile==1.0.1         # via openpyxl
-fake-factory==9999.9.9
+faker==0.9.2
 first==2.0.1
 html5lib==0.9999999       # via bleach
 idna==2.7                 # via cryptography
 importlib==1.0.4
-ipaddress==1.0.22         # via cryptography
+ipaddress==1.0.22         # via cryptography, faker
 jdcal==1.4                # via openpyxl
 kombu==3.0.37             # via celery
 ksp-login==0.5.0
@@ -75,16 +75,18 @@ pyjwt==1.6.4              # via social-auth-core
 pymdown-extensions==2.0
 pyopenssl==18.0.0         # via ndg-httpsclient
 python-akismet==0.4.1     # via django-fluent-comments
+python-dateutil==2.7.5    # via faker
 python-openid==2.2.5      # via social-auth-core
 pytz==2018.5
 pyyaml==3.13              # via tablib
 requests-oauthlib==1.0.0  # via social-auth-core
 requests==2.14.2
-six==1.11.0               # via bleach, cryptography, django-nyt, html5lib, pyopenssl, social-auth-app-django, social-auth-core, trojsten-judge-client, wiki
+six==1.11.0               # via bleach, cryptography, django-nyt, faker, html5lib, pyopenssl, python-dateutil, social-auth-app-django, social-auth-core, trojsten-judge-client, wiki
 social-auth-app-django==1.2.0
 social-auth-core==1.7.0   # via ksp-login, social-auth-app-django
 sorl-thumbnail==12.5.0    # via wiki
 tablib==0.12.1            # via django-import-export
+text-unidecode==1.2       # via faker
 trojsten-judge-client==1.0.1
 unicodecsv==0.14.1        # via tablib
 unidecode==1.0.22

--- a/requirements3.devel.txt
+++ b/requirements3.devel.txt
@@ -19,7 +19,7 @@ certifi==2015.04.28
 cffi==1.11.5              # via bcrypt, cryptography, pynacl
 click==7.0                # via pip-tools
 coverage==4.5.1
-cryptography==2.3.1       # via fabric, paramiko
+cryptography==2.3.1       # via paramiko
 czech-sort==0.4
 defusedxml==0.5.0         # via python3-openid, social-auth-core
 diff-match-patch==20121119  # via django-import-export
@@ -58,12 +58,11 @@ djangorestframework==3.8.2
 ecdsa==0.13
 elasticsearch==6.3.1
 et-xmlfile==1.0.1         # via openpyxl
-fabric==2.4.0
-fake-factory==9999.9.9
+fabric==1.14.0
+faker==0.9.2
 first==2.0.1
 html5lib==0.9999999       # via bleach
 idna==2.7                 # via cryptography
-invoke==1.2.0             # via fabric
 jdcal==1.4                # via openpyxl
 kombu==3.0.37             # via celery
 ksp-login==0.5.0
@@ -81,17 +80,19 @@ pyjwt==1.6.4              # via social-auth-core
 pymdown-extensions==2.0
 pynacl==1.3.0             # via paramiko
 python-akismet==0.4.1     # via django-fluent-comments
+python-dateutil==2.7.5    # via faker
 python3-openid==3.1.0     # via social-auth-core
 pytz==2018.5
 pyyaml==3.13              # via tablib
 requests-oauthlib==1.0.0  # via social-auth-core
 requests==2.14.2
-six==1.11.0               # via bcrypt, bleach, cryptography, django-nyt, html5lib, pip-tools, pynacl, social-auth-app-django, social-auth-core, trojsten-judge-client, wiki
+six==1.11.0               # via bcrypt, bleach, cryptography, django-nyt, faker, html5lib, pip-tools, pynacl, python-dateutil, social-auth-app-django, social-auth-core, trojsten-judge-client, wiki
 social-auth-app-django==1.2.0
 social-auth-core==1.7.0   # via ksp-login, social-auth-app-django
 sorl-thumbnail==12.5.0    # via wiki
 sqlparse==0.2.4
 tablib==0.12.1            # via django-import-export
+text-unidecode==1.2       # via faker
 trojsten-judge-client==1.0.1
 unicodecsv==0.14.1        # via tablib
 unidecode==1.0.22

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -50,7 +50,7 @@ djangorestframework==3.8.2
 ecdsa==0.13
 elasticsearch==6.3.1
 et-xmlfile==1.0.1         # via openpyxl
-fake-factory==9999.9.9
+faker==0.9.2
 first==2.0.1
 html5lib==0.9999999       # via bleach
 jdcal==1.4                # via openpyxl
@@ -65,16 +65,18 @@ psycopg2==2.7.5
 pyjwt==1.6.4              # via social-auth-core
 pymdown-extensions==2.0
 python-akismet==0.4.1     # via django-fluent-comments
+python-dateutil==2.7.5    # via faker
 python3-openid==3.1.0     # via social-auth-core
 pytz==2018.5
 pyyaml==3.13              # via tablib
 requests-oauthlib==1.0.0  # via social-auth-core
 requests==2.14.2
-six==1.11.0               # via bleach, django-nyt, html5lib, social-auth-app-django, social-auth-core, trojsten-judge-client, wiki
+six==1.11.0               # via bleach, django-nyt, faker, html5lib, python-dateutil, social-auth-app-django, social-auth-core, trojsten-judge-client, wiki
 social-auth-app-django==1.2.0
 social-auth-core==1.7.0   # via ksp-login, social-auth-app-django
 sorl-thumbnail==12.5.0    # via wiki
 tablib==0.12.1            # via django-import-export
+text-unidecode==1.2       # via faker
 trojsten-judge-client==1.0.1
 unicodecsv==0.14.1        # via tablib
 unidecode==1.0.22

--- a/trojsten/dbsanitizer/management/commands/sanitize_db.py
+++ b/trojsten/dbsanitizer/management/commands/sanitize_db.py
@@ -1,10 +1,10 @@
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 
 from ...model_sanitizers import ModelSanitizerManager
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = 'Sanitize datatabase, so any sensitive data is removed or anonymized.'
 
-    def handle_noargs(self, **options):
+    def handle(self, **options):
         ModelSanitizerManager.run()

--- a/trojsten/dbsanitizer/model_sanitizers.py
+++ b/trojsten/dbsanitizer/model_sanitizers.py
@@ -7,8 +7,8 @@ import string
 from bulk_update.helper import bulk_update
 from faker import Factory
 
-from trojsten.regal.people.models import User, UserProperty
-from trojsten.regal.contests.models import Task
+from trojsten.people.models import User, UserProperty
+from trojsten.contests.models import Task
 
 accent_chars_lowercase = 'äřéŕťýúíóôášďěüöůĺľžčň'
 accent_chars_uppercase = accent_chars_lowercase.upper()


### PR DESCRIPTION
Chcel som spustiť db sanitizer, ale keďže sa dlhšie nepoužíval, bolo treba:
- zmeniť dependency: `fake-factory -> faker`
- zmeniť imporotvané modely z `trojsten.regal.<app>.models -> trojsten.<app>.models`

Lokálne som si to spustil a zbehlo.

Keď si budeme navzájom distribuovať dumpy databázy, mali by sme defaultne posielať sanitized, nech sú kópie trojstenovej databázy na čo najmenej náhodných miestach.