### PR TITLE
Give partial points for testable zips

### DIFF
--- a/trojsten/rules/ksp.py
+++ b/trojsten/rules/ksp.py
@@ -52,7 +52,8 @@ class KSPResultsGenerator(ResultsGenerator):
             penalized_submits = Submit.objects.filter(
                 task__in=self.get_task_queryset(res_request),
             ).filter(
-                submit_type=submit_constants.SUBMIT_TYPE_SOURCE
+                models.Q(submit_type=submit_constants.SUBMIT_TYPE_SOURCE)
+                | models.Q(submit_type=submit_constants.SUBMIT_TYPE_TESTABLE_ZIP)
             ).filter(
                 models.Q(time__gte=models.F('task__round__end_time'))
                 & models.Q(time__lte=models.F('task__round__second_end_time'))


### PR DESCRIPTION
Teraz mame KSP ulohu 7, kde sa odovzdaval zip s vyriesenymi instanciami miesto kodu a chceme zan ciastocne body.

Myslim, ze ulohy so zipkami su bud taketo (ze sa odovzdavaju vyriesene instancie), alebo este boli kedysi take, kde sa odovzdaval ako keby kod v nejakom inom jazyku (sed, grep), kde sa bud da do vzoraku nedat konkretne "kody", alebo sa prinajhorsom da najprv zverejnit priblizny vzorak a detailny az po doprogramovani. Takze myslim, ze by tymto nemali vzniknut problemy.