### PR TITLE
Fix UTF encoding issue for diploma fields

### DIFF
--- a/trojsten/diplomas/views.py
+++ b/trojsten/diplomas/views.py
@@ -139,7 +139,7 @@ def view_diplomas(request):
 
     context = {
         'form': form,
-        'template_fields': json.dumps(editable_fields, ensure_ascii=False).encode('utf8')
+        'template_fields': json.dumps(editable_fields, ensure_ascii=False)
     }
 
     return render(


### PR DESCRIPTION
Pri migracii na python3 sa rozbilo generovanie diplomov, tento PR to opravuje