### PR TITLE
Fix current user hightlighting in results

### DIFF
--- a/trojsten/results/templates/trojsten/results/parts/results_table.html
+++ b/trojsten/results/templates/trojsten/results/parts/results_table.html
@@ -37,7 +37,7 @@
 {% spaceless %}
 {% if row.active or show_staff %}
 <tr
-    {% if user == row.user %}class="active"{% endif %}
+    {% if user.id == row.user.id %}class="active"{% endif %}
     {# @FIXME(css): Hack until css`s are rewritten #}
     {% if not row.active %}style="opacity: 0.5"{% endif %}
 >


### PR DESCRIPTION
Vo výsledkovke sa má zvýrazňovať prihlásený používateľ, no nedeje sa tak:
https://github.com/trojsten/web/blob/c846c28d3804f36da5e0a3f51e7d095499d0aff2/trojsten/results/templates/trojsten/results/parts/results_table.html#L40

Riadok výsledkovky (ResultsRow) obsahuje serializovaného usera (`row.user`): https://github.com/trojsten/web/blob/c846c28d3804f36da5e0a3f51e7d095499d0aff2/trojsten/results/representation.py#L67-L74
Zatiaľ čo `user` je normálny auth model.

Porovnávanie som upravil tak, aby sa porovnávali IDčka userov.
