### PR TITLE
Optimalizácia stránky s úlohami

### DIFF
--- a/trojsten/contests/models.py
+++ b/trojsten/contests/models.py
@@ -72,7 +72,7 @@ class CompetitionManager(models.Manager):
     def current_site_only(self):
         """Returns only competitions belonging to current site
         """
-        return Site.objects.get(pk=settings.SITE_ID).competition_set.order_by('pk').all()
+        return Competition.objects.filter(sites__id=settings.SITE_ID).order_by('pk').all()
 
 
 @python_2_unicode_compatible

--- a/trojsten/contests/templates/trojsten/contests/parts/task_list.html
+++ b/trojsten/contests/templates/trojsten/contests/parts/task_list.html
@@ -1,7 +1,7 @@
 {% load utils %}
 <!-- Nav tabs -->
 
-{% if categories|length > 1 %}
+{% if categories.count > 1 %}
 <ul class="nav nav-tabs" role="tablist">
     <li class="active">
         <a href="#category-tab-all" role="tab" data-toggle="tab"
@@ -41,7 +41,7 @@
         {% endif %}
     </th>
     {% endif %}
-    {% if categories|length > 0 %}
+    {% if categories.count > 0 %}
         <th width="15%">
             Kategória
         </th>
@@ -69,7 +69,7 @@
                 <a href="{% url 'solution_statement' task_id=task.id %}">vzorák</a>
             </td>
         {% endif %}
-        {% if categories|length > 0 %}
+        {% if categories.count > 0 %}
             <td>
                 {% for category in task.categories.all %}
                     <span class="label label-default category-{{ category }}">{{ category }}</span>

--- a/trojsten/contests/templates/trojsten/contests/parts/task_list.html
+++ b/trojsten/contests/templates/trojsten/contests/parts/task_list.html
@@ -1,7 +1,7 @@
 {% load utils %}
 <!-- Nav tabs -->
 
-{% if categories.count > 1 %}
+{% if categories|length > 1 %}
 <ul class="nav nav-tabs" role="tablist">
     <li class="active">
         <a href="#category-tab-all" role="tab" data-toggle="tab"
@@ -41,7 +41,7 @@
         {% endif %}
     </th>
     {% endif %}
-    {% if categories.count > 0 %}
+    {% if categories|length > 0 %}
         <th width="15%">
             Kategória
         </th>
@@ -69,7 +69,7 @@
                 <a href="{% url 'solution_statement' task_id=task.id %}">vzorák</a>
             </td>
         {% endif %}
-        {% if categories.count > 0 %}
+        {% if categories|length > 0 %}
             <td>
                 {% for category in task.categories.all %}
                     <span class="label label-default category-{{ category }}">{{ category }}</span>

--- a/trojsten/contests/templatetags/statements_parts.py
+++ b/trojsten/contests/templatetags/statements_parts.py
@@ -12,7 +12,7 @@ from ..helpers import get_points_from_submits, slice_tag_list
 
 register = template.Library()
 
-
+# View generuje 6 queryn?
 @register.inclusion_tag('trojsten/contests/parts/task_list.html', takes_context=True)
 def show_task_list(context, round):
     tasks = Task.objects.filter(
@@ -21,9 +21,11 @@ def show_task_list(context, round):
         'number'
     ).select_related(
         'round', 'round__semester', 'round__semester__competition'
+    ).prefetch_related(
+        'categories', 'categories__competition'
     )
     # Select all categories which are represented by at least one task in displayed round.
-    categories = Category.objects.filter(task__in=tasks.values_list('pk', flat=True)).distinct()
+    categories = Category.objects.filter(task__in=tasks.values_list('pk', flat=True)).distinct().select_related('competition')
 
     data = {
         'round': round,

--- a/trojsten/contests/templatetags/statements_parts.py
+++ b/trojsten/contests/templatetags/statements_parts.py
@@ -12,6 +12,7 @@ from ..helpers import get_points_from_submits, slice_tag_list
 
 register = template.Library()
 
+
 @register.inclusion_tag('trojsten/contests/parts/task_list.html', takes_context=True)
 def show_task_list(context, round):
     tasks = Task.objects.filter(

--- a/trojsten/contests/templatetags/statements_parts.py
+++ b/trojsten/contests/templatetags/statements_parts.py
@@ -12,7 +12,6 @@ from ..helpers import get_points_from_submits, slice_tag_list
 
 register = template.Library()
 
-# View generuje 6 queryn?
 @register.inclusion_tag('trojsten/contests/parts/task_list.html', takes_context=True)
 def show_task_list(context, round):
     tasks = Task.objects.filter(


### PR DESCRIPTION
Stránka s úlohami má v láske otravovať databázu.

Zmeny:
- models.py: Naozaj potrebujeme, aby `Competition.current_site_only()` najprv vytiahol z Db model aktuálnej stránky a potom získaval competition_set?
- statements_parts.py: Prefetchol som kategórie + competition kategórie (používajú sa v task_list.html). A ešte som pri načítavaní všetkých kategórií načítal competition, keďže `__str__` kategórie ho používa. (Tento zvlášť dotaz na categories by sa dal vynechať a zoznam poskladať z dát tasks)

Tieto zmeny znížili počet dotazov pri mojich testoch (6 úloh, 2 kategórie) z 35 na 14 (stránka /ulohy) a z 37 na 16 (stránka /ulohy/id) + počet dotazov nezávisí od počtu úloh, ako doteraz :) (pri 12tich úlohách až 49 dotazov)