### PR TITLE
Oprava rozhádzaného formulára vlastností pri chybe

### DIFF
--- a/trojsten/people/templates/trojsten/people/settings.html
+++ b/trojsten/people/templates/trojsten/people/settings.html
@@ -46,7 +46,9 @@
                                 <label class="col-md-3 control-label">{{ field.field.choices|choice_text:field.value }}</label>
                                 <input type="hidden" name="{{ field.html_name }}" value="{{ field.value }}"/>
                             {% else %}
-                                {{ field | bootstrap_inline}}
+                                <div class="col-md-3">
+                                    {{ field | bootstrap_inline}}
+                                </div>
                             {% endif %}
                         {% elif field.name == "value" %}
                             <span class="col-md-7">
@@ -59,9 +61,6 @@
                                 {{ field | bootstrap_inline}}
                             </span>
                         {% endif %}
-                        {% for error in field.errors %}
-                            <span class="help-block">{{ error }}</span>
-                        {% endfor %}
                     {% endfor %}
                     </div>
                   {% endfor %}

--- a/trojsten/people/tests.py
+++ b/trojsten/people/tests.py
@@ -789,3 +789,20 @@ class UserPropsFormSetTests(TestCase):
             'properties-0-user': self.user.id
         })
         self.assertFalse(f.is_valid())
+
+    def test_invalid_form_message(self):
+        self.client.force_login(self.user)
+
+        response = self.client.post(reverse('trojsten_account_settings'), {
+            'user_props_submit': 'Odoslať',
+            'properties-TOTAL_FORMS': 1,
+            'properties-INITIAL_FORMS': 0,
+            'properties-MIN_NUM_FORMS': 0,
+            'properties-MAX_NUM_FORMS': 1000,
+            'properties-0-key': '',
+            'properties-0-value': 'abc',
+            'properties-0-id': '',
+            'properties-0-user': self.user.id
+        })
+
+        self.assertContains(response, _('This field is required.'))


### PR DESCRIPTION
Zobrazovanie fields.error rieši priamo `| bootstrap_inline`, takže je tam navyše a rozbíja layout. Taktiež field `key` nebol obsiahnutý v žiadnom kontajneri, takže si zobral celú šírku obrazovky.

Closes #1172 