### PR TITLE
Wrap judge output in <pre>

### DIFF
--- a/trojsten/submit/templates/trojsten/submit/protocol.html
+++ b/trojsten/submit/templates/trojsten/submit/protocol.html
@@ -35,7 +35,7 @@
                 <tr>
                 <td colspan="3"  style="padding:0">
                     <div class="collapse" id="collapse{{ forloop.counter0 }}">
-                        <pre>{{ test.details|linebreaksbr }}</pre>
+                        <pre>{{ test.details }}</pre>
                     </div>
                 </td>
                 </tr>

--- a/trojsten/submit/templates/trojsten/submit/protocol.html
+++ b/trojsten/submit/templates/trojsten/submit/protocol.html
@@ -34,7 +34,9 @@
                     {% if test.showDetails %}
                 <tr>
                 <td colspan="3"  style="padding:0">
-                        <div  class="collapse" id="collapse{{ forloop.counter0 }}"> {{ test.details|linebreaksbr }}</div>
+                    <div class="collapse" id="collapse{{ forloop.counter0 }}">
+                        <pre>{{ test.details|linebreaksbr }}</pre>
+                    </div>
                 </td>
                 </tr>
                    {% endif %}

--- a/trojsten/submit/templates/trojsten/submit/protocol.html
+++ b/trojsten/submit/templates/trojsten/submit/protocol.html
@@ -35,7 +35,7 @@
                 <tr>
                 <td colspan="3"  style="padding:0">
                     <div class="collapse" id="collapse{{ forloop.counter0 }}">
-                        <pre>{{ test.details }}</pre>
+                        <pre><samp>{{ test.details }}</samp></pre>
                     </div>
                 </td>
                 </tr>


### PR DESCRIPTION
Na "žiadosť" Samuela:
![image](https://user-images.githubusercontent.com/11409143/60540857-82bd6a80-9d10-11e9-90ac-fa8d9d58211e.png)

Neviem, či sa v `test.details` môže ocitnúť aj výstup, ktorý nepochádza z testovača, ale nemalo by to vadiť, iba to bude ináč naformátované.