### PR TITLE
Use STATIC_URL for specifying mathjax config path.

### DIFF
--- a/trojsten/templates/trojsten/layout/base.html
+++ b/trojsten/templates/trojsten/layout/base.html
@@ -52,7 +52,7 @@
           tex2jax: {inlineMath: [["$","$"],["\\(","\\)"]]},
           TeX: {extensions: ["AMSmath.js","AMSsymbols.js", "[Contrib]/siunitx/siunitx.js"]}
         });
-        MathJax.Ajax.config.path["Contrib"] = "{% static "js" %}";
+        MathJax.Ajax.config.path["Contrib"] = "{{ STATIC_URL }}js";
       </script>
       <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
       <script src="{% static "js/"|add:SITE.folder|add:"/analytics.js" %}" type="text/javascript"></script>


### PR DESCRIPTION
This prevents issues with ManifestStaticFilesStorage not being able to generate hash for folders.