### PR TITLE
Fix results table head overflow on mobile.

### DIFF
--- a/trojsten/results/templates/trojsten/results/parts/results_table.html
+++ b/trojsten/results/templates/trojsten/results/parts/results_table.html
@@ -4,7 +4,12 @@
 {% addtoblock "js" %}
     <script type="text/javascript" src="{% static 'js/vendor/jquery.floatThead.min.js' %}"></script>
     <script type="text/javascript">
-        $(() => $('.results-table').floatThead({top:60}));
+        $(() => $('.results-table').floatThead({
+            top: 60,
+            responsiveContainer: function($table){
+                return $table.closest('.table-responsive');
+            }
+        }));
     </script>
 {% endaddtoblock %}
 


### PR DESCRIPTION
![Peek 2019-11-02 20-32](https://user-images.githubusercontent.com/11409143/68076020-f0a59b80-fdaf-11e9-9bb2-1c2e313c4652.gif)

before:
![image](https://user-images.githubusercontent.com/11409143/68076032-103cc400-fdb0-11e9-96b6-44dba46bd10e.png)
