### PR TITLE
Remove string locations from django.po

### DIFF
--- a/trojsten/locale/sk/LC_MESSAGES/django.po
+++ b/trojsten/locale/sk/LC_MESSAGES/django.po
@@ -1,30 +1,22 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-06 21:54+0200\n"
+"POT-Creation-Date: 2019-11-03 13:53+0100\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-#: trojsten/contact_form/forms.py:13
 msgid "Subject"
 msgstr "Predmet"
 
-#: trojsten/contact_form/forms.py:20 trojsten/contact_form/tests.py:59
-#: trojsten/contact_form/tests.py:68 trojsten/diplomas/models.py:47
 msgid "Name"
 msgstr "Meno"
 
-#: trojsten/contact_form/forms.py:21 trojsten/contact_form/tests.py:60
-#: trojsten/contact_form/tests.py:69
 msgid "Email"
 msgstr "E-mail"
 
-#: trojsten/contact_form/forms.py:22 trojsten/contact_form/tests.py:61
-#: trojsten/contact_form/tests.py:70
 msgid "Message"
 msgstr "Správa"
 
-#: trojsten/contact_form/templates/contact_form/contact_form.html:19
 #, python-format
 msgid ""
 "\n"
@@ -42,7 +34,6 @@ msgstr ""
 "alebo priamo vedúcemu uvedenému pri úlohe.\n"
 "    "
 
-#: trojsten/contact_form/templates/contact_form/contact_form.html:29
 msgid ""
 "If you have found any problem with our web site, please let us know using "
 "the following form."
@@ -50,100 +41,73 @@ msgstr ""
 "Ak ste objavili chybu na našej stránke, prosím, dajte nám vedieť použitím "
 "nasledujúceho formulára."
 
-#: trojsten/contests/forms.py:15
 msgid "Category doesn't correspond with competition."
 msgstr ""
 
 # pdf file names
-#: trojsten/contests/models.py:261
 msgid "year"
 msgstr "ročník"
 
-#: trojsten/contests/models.py:263
 msgid "round"
 msgstr "kolo"
 
-#: trojsten/contests/models.py:265
 msgid "solutions"
 msgstr "vzoráky"
 
-#: trojsten/contests/models.py:265
 msgid "tasks"
 msgstr "zadania"
 
-#: trojsten/contests/models.py:328
 msgid "Send notification to reviewers about new description submit"
 msgstr "Zaslať opravovateľom notifikáciu o submite popisu"
 
-#: trojsten/contests/models.py:331
 msgid "Send notification to reviewers about new code submit"
 msgstr "Zaslať opravovateľom notifikáciu o submite kódu"
 
-#: trojsten/contests/models.py:401
 msgid "task"
 msgstr "úloha"
 
-#: trojsten/contests/models.py:403
 msgid "organizer"
 msgstr "vedúci"
 
-#: trojsten/contests/models.py:405
 msgid "reviewer"
 msgstr "opravovateľ"
 
-#: trojsten/contests/models.py:406
 msgid "solution writer"
 msgstr "vzorákovač"
 
-#: trojsten/contests/models.py:407
 msgid "proofreader"
 msgstr "recenzovač"
 
-#: trojsten/contests/models.py:409
 msgid "role"
 msgstr "funkcia"
 
-#: trojsten/contests/models.py:412
 msgid "Assigned user"
 msgstr "Pridelený človek"
 
-#: trojsten/contests/models.py:413
 msgid "Assigned people"
 msgstr "Pridelení ľudia"
 
-#: trojsten/contests/templates/trojsten/contests/dashboard.html:6
-#: trojsten/contests/templates/trojsten/contests/dashboard.html:9
 msgid "Dashboard"
 msgstr "Nástenka"
 
-#: trojsten/contests/templates/trojsten/contests/dashboard.html:13
 msgid "Active rounds"
 msgstr "Aktuálne kolá"
 
-#: trojsten/contests/templates/trojsten/contests/dashboard.html:24
-#: trojsten/contests/tests.py:630 trojsten/contests/tests.py:644
-#: trojsten/contests/tests.py:662 trojsten/contests/tests.py:676
-#: trojsten/contests/tests.py:693
 msgid "There is no active round currently."
 msgstr "Aktuálne neprebieha žiadne kolo."
 
-#: trojsten/contests/templates/trojsten/contests/dashboard.html:28
 msgid "News"
 msgstr "Novinky"
 
-#: trojsten/contests/templates/trojsten/contests/dashboard.html:31
 msgid "More news &raquo;"
 msgstr "Viac noviniek &raquo;"
 
-#: trojsten/contests/templates/trojsten/contests/parts/progress.html:10
 msgid "Submit programs until"
 msgstr "Doprogramovanie do"
 
-#: trojsten/contests/templates/trojsten/contests/parts/progress.html:12
 msgid "End of the round"
 msgstr "Koniec kola"
 
-#: trojsten/contests/templates/trojsten/contests/parts/progress.html:26
 msgid ""
 "\n"
 "      Don't submit descriptions.\n"
@@ -157,266 +121,196 @@ msgstr ""
 "ktoré dostanete časť bodov.\n"
 "      "
 
-#: trojsten/contests/templates/trojsten/contests/parts/progress.html:36
 msgid "The round has finished."
 msgstr "Kolo už skončilo."
 
-#: trojsten/contests/templates/trojsten/contests/parts/progress.html:39
 msgid "View the solution."
 msgstr "Pozrieť vzorové riešenie."
 
 # Task Statements
-#: trojsten/contests/templatetags/statements_parts.py:93
 #, python-format
 msgid "%(count)d day"
 msgstr "%(count)d deň"
 
-#: trojsten/contests/templatetags/statements_parts.py:96
 #, python-format
 msgid "%(count)d hour"
 msgstr "%(count)d hodina"
 
-#: trojsten/contests/templatetags/statements_parts.py:99
 #, python-format
 msgid "%(count)d minute"
 msgstr "%(count)d minúta"
 
-#: trojsten/contests/templatetags/statements_parts.py:102
 #, python-format
 msgid "%(count)d second"
 msgstr "%(count)d sekunda"
 
-#: trojsten/diplomas/admin.py:44
 msgid "authorized groups"
 msgstr "autorizované skupiny"
 
-#: trojsten/diplomas/admin.py:49
 msgid "sources"
 msgstr "zdroje"
 
-#: trojsten/diplomas/forms.py:18
 msgid "Template"
 msgstr "Šablóna"
 
-#: trojsten/diplomas/forms.py:29
 msgid "Participants data"
 msgstr "Dáta účastníkov"
 
-#: trojsten/diplomas/forms.py:33
 msgid "Join into one PDF"
 msgstr "Spojiť do jedného PDF"
 
-#: trojsten/diplomas/forms.py:54
 msgid "Failed to parse the input data"
 msgstr "Chyba pri spracovaní dát"
 
-#: trojsten/diplomas/models.py:25
 msgid "Source name"
 msgstr "Názov zdroja"
 
-#: trojsten/diplomas/models.py:27
 msgid "Source class"
 msgstr "Trieda zdroja"
 
-#: trojsten/diplomas/models.py:29
 msgid "Add to default sources"
 msgstr "Pridať do základných zdrojov"
 
-#: trojsten/diplomas/models.py:41
 msgid "Data source for diplomas"
 msgstr "Zdroj dát pre diplomy"
 
-#: trojsten/diplomas/models.py:42
 msgid "Data sources for diplomas"
 msgstr "Zdroje dát pre diplomy"
 
-#: trojsten/diplomas/models.py:50
 msgid "Sources"
 msgstr "Zdroje"
 
-#: trojsten/diplomas/models.py:54
 msgid "Authorized groups"
 msgstr "Autorizované skupiny"
 
-#: trojsten/diplomas/models.py:56
 msgid "The groups that are authorized to use this template."
 msgstr "Skupiny s povolením používať túto šablónu"
 
-#: trojsten/diplomas/models.py:60
 msgid "Diploma template"
 msgstr "Šablóna diplomu"
 
-#: trojsten/diplomas/models.py:61
 msgid "Diploma templates"
 msgstr "Šablóny diplomov"
 
-#: trojsten/diplomas/templates/trojsten/diplomas/parts/sources.html:9
 msgid "External input options"
 msgstr "Výber externého zdroja"
 
-#: trojsten/diplomas/templates/trojsten/diplomas/sources/fileupload.html:6
 msgid "Choose a file"
 msgstr "Nahrať súbor"
 
-#: trojsten/diplomas/templates/trojsten/diplomas/sources/naboj.html:8
 msgid "Categories"
 msgstr "Kategórie"
 
-#: trojsten/diplomas/templates/trojsten/diplomas/sources/naboj.html:19
 msgid "Limit to first"
 msgstr "Iba prvých"
 
-#: trojsten/diplomas/templates/trojsten/diplomas/sources/naboj.html:26
 msgid ""
 "Scrape data directly from URL (last resort in case Naboj site changes "
 "structure)"
 msgstr "Stiahni dáta priamo z URL (poistka pre prípad zmien Náboj stránky)"
 
-#: trojsten/diplomas/templates/trojsten/diplomas/sources/naboj.html:27
 msgid "Results URL"
 msgstr "URL výsledkov"
 
-#: trojsten/diplomas/templates/trojsten/diplomas/sources/naboj.html:29
 msgid "This field is not required"
 msgstr "Toto pole nie je povinné."
 
-#: trojsten/diplomas/templates/trojsten/diplomas/sources/naboj.html:36
 msgid "Load"
 msgstr "Načítať"
 
-#: trojsten/diplomas/templates/trojsten/diplomas/view_diplomas.html:9
-#: trojsten/diplomas/templates/trojsten/diplomas/view_diplomas.html:12
 msgid "Diplomas"
 msgstr "Diplomy"
 
-#: trojsten/diplomas/templates/trojsten/diplomas/view_diplomas.html:25
 msgid "Multiple diplomas"
 msgstr "Viacero diplomov"
 
-#: trojsten/diplomas/templates/trojsten/diplomas/view_diplomas.html:26
 msgid "Single diploma"
 msgstr "Jeden diplom"
 
-#: trojsten/diplomas/templates/trojsten/diplomas/view_diplomas.html:34
 msgid "Preview"
 msgstr "Náhľad"
 
-#: trojsten/diplomas/templates/trojsten/diplomas/view_diplomas.html:59
-#: trojsten/diplomas/templates/trojsten/diplomas/view_diplomas.html:97
 msgid "Generate"
 msgstr "Generovať"
 
-#: trojsten/diplomas/templates/trojsten/diplomas/view_diplomas.html:67
 msgid "Replaceable fields:"
 msgstr "Nahraditeľné polia:"
 
-#: trojsten/diplomas/templates/trojsten/diplomas/view_diplomas.html:84
 msgid "Output options"
 msgstr "Možnosti výstupu"
 
-#: trojsten/diplomas/views.py:28
 msgid "Template does not exist"
 msgstr "Šablóna neexistuje"
 
-#: trojsten/diplomas/views.py:36
 msgid "You do not have access to this template"
 msgstr "K tejto šablóne nemáte prístup"
 
-#: trojsten/events/templates/trojsten/events/participants_and_organizers_list.html:36
-#: trojsten/events/templates/trojsten/events/participants_and_organizers_list.html:56
-#: trojsten/people/forms.py:79
-#: trojsten/results/templates/trojsten/results/parts/results_table.html:77
 msgid "Other school"
 msgstr "Iná škola"
 
-#: trojsten/login/views.py:29
 msgid "Logout successful"
 msgstr "Odhlásenie úspešné"
 
-#: trojsten/people/admin.py:170
 msgid "Personal info"
 msgstr "Osobné údaje"
 
-#: trojsten/people/admin.py:173
 msgid "Address"
 msgstr "Adresa"
 
-#: trojsten/people/admin.py:174
 msgid "School"
 msgstr "Škola"
 
-#: trojsten/people/admin.py:175 trojsten/people/forms.py:260
 msgid "Password"
 msgstr "Heslo"
 
-#: trojsten/people/admin.py:179
 msgid "Permissions"
 msgstr "Práva"
 
-#: trojsten/people/admin.py:182
 msgid "Important dates"
 msgstr "Dôležité dátumy"
 
-#: trojsten/people/admin.py:288
 msgid "Users merged succesfully."
 msgstr "Používatelia spojení úspešne."
 
-#: trojsten/people/forms.py:33 trojsten/people/forms.py:52
 msgid "Street"
 msgstr "Ulica"
 
-#: trojsten/people/forms.py:34 trojsten/people/forms.py:53
 msgid "Town"
 msgstr "Mesto"
 
-#: trojsten/people/forms.py:35 trojsten/people/forms.py:54
 msgid "Postal code"
 msgstr "PSČ"
 
-#: trojsten/people/forms.py:36 trojsten/people/forms.py:55
 msgid "Country"
 msgstr "Krajina"
 
-#: trojsten/people/forms.py:39
 msgid "home"
 msgstr "domov"
 
-#: trojsten/people/forms.py:40
 msgid "school"
 msgstr "do školy"
 
-#: trojsten/people/forms.py:41
 msgid "other address (e. g. to a dormitory)"
 msgstr "na inú adresu (napr. na internát)"
 
-#: trojsten/people/forms.py:46
 msgid "Correspondence address"
 msgstr "Korešpondenčná adresa"
 
-#: trojsten/people/forms.py:48
 msgid "Choose, where you want to accept mails."
 msgstr "Vyber, kam ti máme posielať poštu."
 
-#: trojsten/people/forms.py:76
 msgid "Gender"
 msgstr "Pohlavie"
 
-#: trojsten/people/forms.py:95 trojsten/people/forms.py:100
-#: trojsten/people/forms.py:105 trojsten/people/forms.py:112
-#: trojsten/people/forms.py:120 trojsten/people/forms.py:128
-#: trojsten/people/forms.py:137
 msgid "This field is required."
 msgstr "Toto pole je povinné."
 
-#: trojsten/people/forms.py:147
 msgid "Your graduation year is too far in the past."
 msgstr "Tvoj rok maturity je príliš ďaleko v minulosti."
 
-#: trojsten/people/forms.py:152
 msgid "Your graduation year is too far in the future."
 msgstr "Tvoj rok maturity je príliš ďaleko v budúcnosti."
 
-#: trojsten/people/forms.py:163
 msgid ""
 "We cannot send you correspondence to school when you don't choose any "
 "school. If your school is not in the list write us in an e-mail that you "
@@ -426,15 +320,12 @@ msgstr ""
 "tvoja škola nenachádza v zozname, napíš v e-maili, že ti máme posielať poštu "
 "na školu"
 
-#: trojsten/people/forms.py:262
 msgid "Password confirmation"
 msgstr "Potvrdenie hesla"
 
-#: trojsten/people/forms.py:264
 msgid "Enter the same password as above, for verification."
 msgstr "Zadaj rovnaké heslo ako vyššie pre jeho overenie"
 
-#: trojsten/people/forms.py:296
 msgid ""
 "We recommend choosing a strong passphrase but we don't enforce any "
 "ridiculous constraints on your passwords."
@@ -442,92 +333,63 @@ msgstr ""
 "Odporúčame ti vybrať silné heslo, ale nebudeme od teba vyžadovať žiadne "
 "smiešne požiadavky"
 
-#: trojsten/people/forms.py:306
 msgid ""
 "Since you're logging in using an external provider, this field is optional; "
 "however, by supplying it, you will be able to log in using a password. "
 msgstr ""
 
-#: trojsten/people/forms.py:318
 msgid "The two password fields didn't match."
 msgstr ""
 
-#: trojsten/people/forms.py:463
 msgid "Points have to be non-negative and at most {}."
 msgstr "Body musia byť nezáporné a najviac {}."
 
-#: trojsten/people/forms.py:471
 msgid "The value has to be number or {}."
 msgstr "Hodnota musí byť číslo alebo {}."
 
-#: trojsten/people/forms.py:520
 msgid "Round"
 msgstr "Kolo"
 
-#: trojsten/people/forms.py:533 trojsten/people/forms.py:571
-#: trojsten/people/templates/admin/people/duplicateuser/merge_duplicate_users.html:31
-#: trojsten/people/templates/trojsten/people/settings.html:95
-#: trojsten/templates/ksp_login/parts/multiple_forms.html:11
-#: trojsten/templates/ksp_login/parts/single_form.html:10
 msgid "Submit"
 msgstr "Odoslať"
 
-#: trojsten/people/models.py:92
 msgid "Required field for students."
 msgstr "Povinné pre žiakov."
 
-#: trojsten/people/models.py:229
 msgid "Value \"{}\" does not match regex \"{}\"."
 msgstr ""
 
-#: trojsten/people/templates/admin/people/duplicateuser/change_form.html:5
 msgid "Merge candidates"
 msgstr ""
 
-#: trojsten/people/templates/admin/people/duplicateuser/change_form.html:11
-#: trojsten/people/templates/admin/people/duplicateuser/merge_duplicate_users.html:10
 msgid "Merge"
 msgstr ""
 
-#: trojsten/people/templates/admin/people/duplicateuser/merge_duplicate_users.html:6
-#: trojsten/people/templates/admin/people/submitted_tasks.html:6
-#: trojsten/reviews/templates/admin/review_edit.html:6
-#: trojsten/reviews/templates/admin/review_form.html:6
-#: trojsten/reviews/templates/admin/zip_upload.html:6
 msgid "Home"
 msgstr ""
 
-#: trojsten/people/templates/admin/people/duplicateuser/merge_duplicate_users.html:16
 #, python-format
 msgid "Merge users %(user)s and %(candidate)s"
 msgstr ""
 
-#: trojsten/people/templates/admin/people/duplicateuser/merge_duplicate_users.html:32
 msgid "Reset"
 msgstr "Obnoviť"
 
-#: trojsten/people/templates/admin/people/duplicateuser/merge_duplicate_users.html:33
 msgid "Cancel"
 msgstr "Zrušiť"
 
-#: trojsten/people/templates/admin/people/submitted_tasks.html:7
 msgid "People"
 msgstr "Ľudia"
 
-#: trojsten/people/templates/admin/people/submitted_tasks.html:8
 msgid "Users"
 msgstr "Používatelia"
 
-#: trojsten/people/templates/admin/people/submitted_tasks.html:10
-#: trojsten/people/templates/admin/people/submitted_tasks_button.html:6
 msgid "Submitted tasks"
 msgstr "Odovzdané úlohy"
 
-#: trojsten/people/templates/admin/people/submitted_tasks.html:15
 msgid "Tasks submitted by competitor"
 msgstr "Úlohy odovzdané riešiteľom"
 
-#: trojsten/people/templates/admin/people/submitted_tasks.html:16
 msgid ""
 "\n"
 "You are viewing submits for round:\n"
@@ -535,11 +397,9 @@ msgstr ""
 "\n"
 "Prezeráš si odovzdané úlohy pre kolo:\n"
 
-#: trojsten/people/templates/admin/people/submitted_tasks.html:23
 msgid "Change round"
 msgstr "Zmeň kolo"
 
-#: trojsten/people/templates/admin/people/submitted_tasks.html:27
 #, python-format
 msgid ""
 "\n"
@@ -560,21 +420,15 @@ msgstr ""
 "Políčkami môžeš prechádzať pomocou tabulátora.\n"
 
 # Login
-#: trojsten/people/templates/trojsten/people/additional_registration.html:11
-#: trojsten/people/templates/trojsten/people/additional_registration.html:14
 msgid "Complete Registration"
 msgstr "Dodatočná Registrácia"
 
-#: trojsten/people/templates/trojsten/people/additional_registration.html:23
-#: trojsten/people/tests.py:871
 msgid "You have already filled all required properties."
 msgstr "Momentálne máš vyplnené všetky potrebné údaje."
 
-#: trojsten/people/templates/trojsten/people/parts/additional_registration.html:9
 msgid "We need a little more information"
 msgstr "Potrebujeme ešte zopár údajov"
 
-#: trojsten/people/templates/trojsten/people/parts/additional_registration.html:13
 msgid ""
 "To participate in some competitions, we need you to fill some more data in "
 "addition to those you have filled during registration.\n"
@@ -584,7 +438,6 @@ msgstr ""
 "údaje navyše okrem tých, ktoré si zadal pri registrácii. Pokiaľ ich "
 "nevyplníš, nebudeme ťa zobrazovať vo výsledkovej listine."
 
-#: trojsten/people/templates/trojsten/people/parts/additional_registration.html:17
 msgid ""
 "If you want to prevent this message from showing, you may check \"I do not "
 "want to participate in competition\".\n"
@@ -594,7 +447,6 @@ msgstr ""
 "\"Nechcem sa zapojiť do súťaže\". Toto rozhodnutie môžeš neskôr zmeniť v "
 "nastaveniach v sekcii \"Súťaže\"."
 
-#: trojsten/people/templates/trojsten/people/parts/additional_registration.html:22
 #, python-format
 msgid ""
 "To participate in competition <em>%(competition)s</em> you need to fill:"
@@ -602,69 +454,43 @@ msgstr ""
 "V súťaži <em>%(competition)s</em> potrebujeme ešte aby si vyplnil tieto "
 "údaje:"
 
-#: trojsten/people/templates/trojsten/people/parts/additional_registration.html:33
 #, python-format
 msgid "I do not want to participate in competition %(competition)s."
 msgstr "Nechcem sa zapojiť do súťaže %(competition)s."
 
-#: trojsten/people/templates/trojsten/people/parts/additional_registration.html:37
 msgid "Close"
 msgstr "Zavrieť"
 
-#: trojsten/people/templates/trojsten/people/parts/additional_registration.html:38
 msgid "Fill data"
 msgstr "Vyplniť údaje"
 
-#: trojsten/people/templates/trojsten/people/settings.html:11
-#: trojsten/people/templates/trojsten/people/settings.html:14
 msgid "Account settings"
 msgstr "Nastavenia účtu"
 
-#: trojsten/people/templates/trojsten/people/settings.html:21
 msgid "Profile"
 msgstr "Profil"
 
-#: trojsten/people/templates/trojsten/people/settings.html:22
 msgid "Properties"
 msgstr "Vlastnosti"
 
-#: trojsten/people/templates/trojsten/people/settings.html:23
-#: trojsten/reviews/templates/admin/review_form.html:7
-#: trojsten/reviews/templates/admin/zip_upload.html:7
 msgid "Contests"
 msgstr "Súťaže"
 
-#: trojsten/people/templates/trojsten/people/settings.html:25
-#: trojsten/people/templates/trojsten/people/settings.html:27
 msgid "Login settings"
 msgstr "Nastavenia prihlasovania"
 
-#: trojsten/people/templates/trojsten/people/settings.html:96
 msgid "Add property"
 msgstr "Pridať vlastnosť"
 
-#: trojsten/people/templates/trojsten/people/settings.html:104
 msgid "Choose which competitions would you like to participate in:"
 msgstr "Vyber si súťaže, ktoré chceš riešiť:"
 
-#: trojsten/people/templates/trojsten/people/settings.html:112
 msgid "You can use any of the following services to log in to your account."
 msgstr "Možete použiť ľubovoľnú z nasledujúcich služieb na prihlásenie."
 
-#: trojsten/people/templates/trojsten/people/settings.html:133
-#: trojsten/templates/ksp_login/login.html:4
-#: trojsten/templates/ksp_login/login.html:7
-#: trojsten/templates/ksp_login/parts/include_javascript.html:15
-#: trojsten/templates/ksp_login/parts/login_box.html:44
-#: trojsten/templates/ksp_login/parts/login_box.html:61
-#: trojsten/templates/ksp_login/parts/login_box.html:75
-#: trojsten/templates/ksp_login/parts/login_full_contents.html:47
-#: trojsten/templates/ksp_login/parts/login_full_contents.html:53
-#: trojsten/templates/ksp_login/parts/login_full_contents.html:82
 msgid "Log in"
 msgstr "Prihlásiť sa"
 
-#: trojsten/people/templates/trojsten/people/settings.html:141
 #, python-format
 msgid ""
 "\n"
@@ -679,13 +505,9 @@ msgstr ""
 "stránke</a>.\n"
 "                "
 
-#: trojsten/people/templates/trojsten/people/settings.html:146
-#: trojsten/templates/ksp_login/password.html:5
-#: trojsten/templates/ksp_login/password.html:8
 msgid "Password change"
 msgstr "Zmena hesla"
 
-#: trojsten/people/templates/trojsten/people/settings.html:149
 #, python-format
 msgid ""
 "\n"
@@ -698,271 +520,196 @@ msgstr ""
 "a>.\n"
 "                "
 
-#: trojsten/reviews/forms.py:48
 #, python-format
 msgid "File must be a ZIP archive: %s"
 msgstr "Súbor musí byť ZIP archív: %s"
 
-#: trojsten/reviews/forms.py:84
 msgid "Points are required"
 msgstr "Body sú povinné"
 
-#: trojsten/reviews/forms.py:87
 msgid "User is required"
 msgstr "Používateľ je povinný"
 
-#: trojsten/reviews/forms.py:92
 #, python-format
 msgid "User %s does not exist"
 msgstr "Používateľ %s neexistuje"
 
-#: trojsten/reviews/forms.py:184
 #, python-format
 msgid "Invalid filename %s"
 msgstr "Neplatný názov súboru %s"
 
-#: trojsten/reviews/forms.py:187
 msgid "Must have set points"
 msgstr "Musíš uviesť body"
 
-#: trojsten/reviews/forms.py:204
 msgid "Assigned 2 or more files to the same user."
 msgstr "Rovnaký používateľ má priradené 2 alebo viac súborov."
 
-#: trojsten/reviews/helpers.py:18
 msgid "You should upload a file or specify parent submit."
 msgstr "Mal by si nahrať súbor alebo špecifikovať predchádzajúci submit."
 
-#: trojsten/reviews/templates/admin/review_edit.html:10
-#: trojsten/reviews/templates/admin/review_form.html:10
-#: trojsten/reviews/templates/admin/task_review.html:6
-#: trojsten/reviews/templates/admin/zip_upload.html:10
 msgid "Review"
 msgstr "Opravovanie"
 
-#: trojsten/reviews/templates/admin/review_edit.html:11
-#: trojsten/reviews/templates/admin/review_form.html:64
 msgid "Edit"
 msgstr "Upraviť"
 
-#: trojsten/reviews/templates/admin/review_form.html:8
-#: trojsten/reviews/templates/admin/zip_upload.html:8
 msgid "Task"
 msgstr "Úloha"
 
-#: trojsten/reviews/templates/admin/review_form.html:18
 msgid "Download all original solutions"
 msgstr "Stiahnuť všetky pôvodné riešenia"
 
-#: trojsten/reviews/templates/admin/review_form.html:19
 msgid " (it downloads last submitted solution for each competitor)"
 msgstr " (stiahne pre každého užívateľa posledné odovzdané riešenie)"
 
-#: trojsten/reviews/templates/admin/review_form.html:21
 msgid "Download all reviewed solutions"
 msgstr "Stiahnuť všetky opravené riešenia"
 
-#: trojsten/reviews/templates/admin/review_form.html:22
 msgid " (it downloads reviewed solutions for each competitor if there is any)"
 msgstr " (stiahne pre každého užívateľa opravené riešenie, ak je opravené)"
 
-#: trojsten/reviews/templates/admin/review_form.html:57
-#: trojsten/reviews/templates/admin/submit_form.html:12
-#: trojsten/submit/templates/trojsten/submit/parts/submit_list.html:30
-#: trojsten/submit/templates/trojsten/submit/parts/submit_list.html:36
-#: trojsten/submit/templates/trojsten/submit/parts/submits_for_user_and_round.html:30
-#: trojsten/submit/templates/trojsten/submit/parts/submits_for_user_and_round.html:37
 msgid "Download"
 msgstr "Stiahnuť"
 
-#: trojsten/reviews/templates/admin/review_form.html:63
-#: trojsten/reviews/templates/admin/submit_form.html:9
 msgid "View"
 msgstr "Pozrieť"
 
-#: trojsten/reviews/templates/admin/review_form.html:67
 msgid "Add new review"
 msgstr "Pridaj opravenie"
 
-#: trojsten/reviews/templates/admin/review_form.html:82
 msgid "Update points and comments"
 msgstr "Aktualizuj body a komentáre"
 
-#: trojsten/reviews/templates/admin/submit_form.html:6
 msgid "View task"
 msgstr "Pozrieť úlohu"
 
-#: trojsten/reviews/templates/admin/zip_upload.html:11
 msgid "Upload Zip"
 msgstr "Nahraj Zip"
 
-#: trojsten/reviews/templates/admin/zip_upload.html:31
 msgid "Filename"
 msgstr "Názov súboru"
 
-#: trojsten/reviews/templates/admin/zip_upload.html:32
 msgid "User"
 msgstr "Používateľ"
 
-#: trojsten/reviews/templates/admin/zip_upload.html:33
 msgid "Points"
 msgstr "Body"
 
-#: trojsten/reviews/templates/admin/zip_upload.html:34
 msgid "Comment"
 msgstr "Komentár"
 
-#: trojsten/reviews/views.py:66
 msgid "Successfully uploaded a zip file."
 msgstr "Zip súbor bol úspešne nahraný"
 
-#: trojsten/reviews/views.py:76
 msgid "Points and comments were successfully updated."
 msgstr "Body a komentáre boli úspešne aktualizované"
 
-#: trojsten/reviews/views.py:125
 msgid "Successfully saved the review"
 msgstr "Opravenie bolo úspešne uložené"
 
-#: trojsten/reviews/views.py:189
 #, python-format
 msgid "Missing file of user %s"
 msgstr "Chýba súbor používateľa %s"
 
-#: trojsten/reviews/views.py:211
 #, python-format
 msgid "Missing source file of user %s"
 msgstr "Chýba zdrojový súbor používateľa %s"
 
-#: trojsten/reviews/views.py:219
 #, python-format
 msgid "Missing protocol of user %s"
 msgstr "Chýba protokol používateľa %s"
 
-#: trojsten/reviews/views.py:251
 msgid "Problems with uploaded zip"
 msgstr "Problémy s nahratým zip-om"
 
-#: trojsten/reviews/views.py:257
 msgid "Ignore"
 msgstr "Ignorovať"
 
-#: trojsten/reviews/views.py:301
 msgid "Successfully finished reviewing this task!"
 msgstr "Úspešne dokončené opravovanie tejto úlohy!"
 
-#: trojsten/settings/common.py:378
 msgid "Table of Contents"
 msgstr ""
 
-#: trojsten/submit/constants.py:11
 msgid "reviewed"
 msgstr "opravený"
 
-#: trojsten/submit/constants.py:12
 msgid "in queue"
 msgstr "v poradí"
 
-#: trojsten/submit/constants.py:13
 msgid "finished"
 msgstr "ukončený"
 
-#: trojsten/submit/constants.py:14 trojsten/submit/constants.py:35
 msgid "OK"
 msgstr "OK"
 
 # Submit
-#: trojsten/submit/constants.py:31 trojsten/submit/tests.py:546
 msgid "Wrong answer"
 msgstr "Zlá odpoveď"
 
-#: trojsten/submit/constants.py:32
 msgid "Compilation error"
 msgstr "Chyba počas kompilácie"
 
-#: trojsten/submit/constants.py:33
 msgid "Time limit exceeded"
 msgstr "Prekročený časový limit"
 
-#: trojsten/submit/constants.py:34
 msgid "Memory limit exceeded"
 msgstr "Prekročený pamäťový limit"
 
-#: trojsten/submit/constants.py:36
 msgid "Runtime exception"
 msgstr "Chyba počas behu programu"
 
-#: trojsten/submit/constants.py:37
 msgid "Security exception"
 msgstr "Pokus o narušenie bezpečnosti"
 
-#: trojsten/submit/constants.py:38
 msgid "Ignored"
 msgstr ""
 
-#: trojsten/submit/constants.py:39
 msgid "Protocol corrupted"
 msgstr "Nečitateľný protokol"
 
-#: trojsten/submit/forms.py:72
 msgid "Submit file"
 msgstr "Nahrať súbor"
 
-#: trojsten/submit/forms.py:73
 msgid "Here you can upload a file with submit description"
 msgstr "Tu môžeš nahrať súbor s popisom riešenia"
 
-#: trojsten/submit/forms.py:84
 msgid "You can attach a submit file only to descriptions."
 msgstr "Nahrať súbor môžeš len k popisom."
 
-#: trojsten/submit/templates/trojsten/submit/all_submits_page.html:7
-#: trojsten/submit/templates/trojsten/submit/all_submits_page.html:10
 msgid "My submitted tasks"
 msgstr "Moje odovzdané úlohy"
 
-#: trojsten/submit/templates/trojsten/submit/parts/submit_list.html:37
 msgid "Show comment"
 msgstr "Pozri komentár"
 
-#: trojsten/submit/templates/trojsten/submit/parts/submit_list.html:75
-#: trojsten/submit/templates/trojsten/submit/parts/submit_list.html:92
 msgid "Detaily"
 msgstr ""
 
-#: trojsten/submit/templates/trojsten/submit/parts/submits_for_user_and_round.html:39
 msgid "View comment"
 msgstr "Pozri komentár"
 
-#: trojsten/submit/templates/trojsten/submit/parts/submits_for_user_and_round.html:53
 msgid "Details"
 msgstr "Detaily"
 
-#: trojsten/submit/templates/trojsten/submit/view_submit.html:43
 msgid "Protocol"
 msgstr "Protokol"
 
-#: trojsten/submit/templates/trojsten/submit/view_submit.html:44
 msgid "Program"
 msgstr "Program"
 
-#: trojsten/submit/templates/trojsten/submit/view_submit.html:45
 msgid "Submits"
 msgstr "Submity"
 
-#: trojsten/submit/templates/trojsten/submit/view_submit.html:58
 msgid "Program source is not available."
 msgstr "Zdrojový kód programu nie je k dispozícií."
 
-#: trojsten/submit/templates/trojsten/submit/view_submit.html:69
 msgid "There are no data about this submit."
 msgstr "K tomuto submitu neexistujú žiadne dáta."
 
-#: trojsten/submit/views.py:355
 msgid "[Trojstenweb] User submission detected"
 msgstr "[Trojstenweb] Nový submit uživateľa"
 
-#: trojsten/submit/views.py:357
 #, python-brace-format
 msgid ""
 "{name} submitted solution to task {task}\n"
@@ -971,7 +718,6 @@ msgstr ""
 "Uživateľ {name} submitol riešenie úlohy {task}\n"
 "\n"
 
-#: trojsten/submit/views.py:359
 #, python-brace-format
 msgid ""
 "Link for reviewing: {review_link}\n"
@@ -980,7 +726,6 @@ msgstr ""
 "Link na opravovanie: {review_link}\n"
 "\n"
 
-#: trojsten/submit/views.py:363
 #, python-brace-format
 msgid ""
 "Submit link: {submit_link}\n"
@@ -991,7 +736,6 @@ msgstr ""
 "\n"
 "Toto je automatizovaná správa, neodpovedajte na ňu"
 
-#: trojsten/submit/views.py:480
 msgid ""
 "You have successfully submitted your description, it will be reviewed after "
 "the round finishes."
@@ -999,7 +743,6 @@ msgstr ""
 "Úspešne sa ti podarilo submitnúť popis, po skončení kola ti ho vedúci "
 "opravia."
 
-#: trojsten/submit/views.py:489
 msgid ""
 "You have submitted your description after the deadline. It is not counted in "
 "results."
@@ -1007,95 +750,71 @@ msgstr ""
 "Nahral si svoj popis riešenia po termíne kola. Nebude zarátaný vo "
 "výsledkovke."
 
-#: trojsten/templates/comments/comment.html:23
 msgid "Preview of your comment"
 msgstr "Náhľad komentára"
 
-#: trojsten/templates/comments/comment.html:32
 msgid "Anonymous"
 msgstr "Anonym"
 
-#: trojsten/templates/comments/comment.html:39
 #, python-format
 msgid "on %(submit_date)s"
 msgstr "%(submit_date)s"
 
-#: trojsten/templates/comments/comment.html:46
 msgid "reply"
 msgstr "reagovať"
 
-#: trojsten/templates/comments/form.html:4
 msgid "Comments are closed."
 msgstr "Diskusia je uzavretá."
 
-#: trojsten/templates/comments/form.html:24
 msgid "Post"
 msgstr "Odoslať"
 
-#: trojsten/templates/ksp_login/parts/associated_accounts_list.html:9
 msgid "Provider"
 msgstr ""
 
-#: trojsten/templates/ksp_login/parts/associated_accounts_list.html:10
 msgid "Account"
 msgstr ""
 
-#: trojsten/templates/ksp_login/parts/associated_accounts_list.html:32
 msgid "Disconnect"
 msgstr ""
 
-#: trojsten/templates/ksp_login/parts/associated_accounts_list.html:42
 msgid "You don't have any services associated with your account."
 msgstr ""
 
-#: trojsten/templates/ksp_login/parts/login_box.html:11
 msgid "Logged in as"
 msgstr ""
 
 # Login
-#: trojsten/templates/ksp_login/parts/login_box.html:22
 msgid "Site administration"
 msgstr "Správa stránky"
 
-#: trojsten/templates/ksp_login/parts/login_box.html:29
 msgid "Settings"
 msgstr ""
 
-#: trojsten/templates/ksp_login/parts/login_box.html:38
 msgid "Log out"
 msgstr ""
 
-#: trojsten/templates/ksp_login/parts/login_box.html:67
 msgid "More login options"
 msgstr ""
 
-#: trojsten/templates/ksp_login/parts/login_full_contents.html:85
 msgid "Forgotten password"
 msgstr ""
 
 # Login
-#: trojsten/templates/ksp_login/parts/login_full_contents.html:96
-#: trojsten/templates/ksp_login/registration.html:5
-#: trojsten/templates/ksp_login/registration.html:8
 msgid "Registration"
 msgstr "Registrácia"
 
-#: trojsten/templates/ksp_login/parts/login_full_contents.html:112
 msgid "Log in with your Trojsten account"
 msgstr ""
 
-#: trojsten/templates/ksp_login/registration.html:14
 msgid ""
 "Welcome, new user. You only need to give us a few details in order to finish "
 "the registration process."
 msgstr ""
 
-#: trojsten/templates/search/search.html:5
-#: trojsten/templates/search/search.html:9
 msgid "Search results for:"
 msgstr "Výsledky hľadania pre"
 
-#: trojsten/templates/search/search.html:23
 #, python-format
 msgid ""
 "\n"
@@ -1104,32 +823,23 @@ msgstr ""
 "\n"
 "          Nájdených <strong>%(cnt)s</strong> výskytov."
 
-#: trojsten/templates/search/search.html:32
 msgid "Title"
 msgstr "Názov"
 
-#: trojsten/templates/search/search.html:33
 msgid "Last modified"
 msgstr "Naposledy upravené"
 
-#: trojsten/templates/search/search.html:58
 msgid "There are no articles in this level"
 msgstr "Na tejto úrovni nie sú žiadne články."
 
-#: trojsten/templates/search/search.html:68
-#: trojsten/templates/search/search.html:70
 msgid "Previous"
 msgstr "Predchádzajúca"
 
-#: trojsten/templates/search/search.html:79
-#: trojsten/templates/search/search.html:81
 msgid "Next"
 msgstr "Nasledujúca"
 
-#: trojsten/templates/wiki/article.html:19
 msgid "locked"
 msgstr ""
 
-#: trojsten/templates/wiki/article.html:40
 msgid "This article was last modified:"
 msgstr "Čas poslednej úpravy:"

--- a/trojsten/management/commands/makemessages.py
+++ b/trojsten/management/commands/makemessages.py
@@ -1,0 +1,5 @@
+from django.core.management.commands import makemessages
+
+
+class Command(makemessages.Command):
+    xgettext_options = makemessages.Command.xgettext_options + ["--add-location=never"]


### PR DESCRIPTION
Set `--add-location=never` by default in the makemessages command and delete the locations from django.py.

Can be overriden by specifying `--add-location=file` or `--add-location=full` if needed for debugging purposes.