### PR TITLE
Fix tooltips overflowing parent container.

### DIFF
--- a/trojsten/static/js/bootstrap-load-plugins.js
+++ b/trojsten/static/js/bootstrap-load-plugins.js
@@ -1,3 +1,6 @@
 $(document).ready(function() {
-    $("body").tooltip({ selector: '[data-toggle=tooltip]' });
+    $("body").tooltip({
+        selector: '[data-toggle=tooltip]',
+        container: 'body'
+    });
 });


### PR DESCRIPTION
Momentálne, ak tooltip patrí do nejakého elementu, môže sa stať, že ho nebude vidno (napr. vo výsledkovke, keď ukážeš na číslo úlohy, uvidíš len ten spodný zobáčik). By default sa tooltip vytvára v najbližšiom parentovi. Po novom sa bude tooltip vytvárať vždy v roote (body), takže ho bude vždy vidno.