### PR TITLE
fix docker-compose for newer postgres images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ x-webenv: &webenv
   TROJSTENWEB_DATABASE_URL: db
   TROJSTENWEB_DATABASE_USER: trojsten
   TROJSTENWEB_DATABASE_NAME: trojsten
+  TROJSTENWEB_DATABASE_PASSWORD: trojsten
 
 services:
   db:
@@ -21,6 +22,7 @@ services:
     environment:
       - POSTGRES_USER=trojsten
       - POSTGRES_DB=trojsten
+      - POSTGRES_PASSWORD=trojsten
   web:
     <<: *web
     ports:


### PR DESCRIPTION
Newer postgresql images require `POSTGRES_PASSWORD` environment variable to be set and non-empty. This causes new developers to encounter a bug with starting their `db` image with `docker-compose`. This should fix that.