### PR TITLE
Zobrazovať upozornenie v admine, keď sú skryté body z výsledkovky

### DIFF
--- a/trojsten/locale/sk/LC_MESSAGES/django.po
+++ b/trojsten/locale/sk/LC_MESSAGES/django.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-01-04 18:11+0000\n"
+"POT-Creation-Date: 2020-06-07 14:06+0000\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 
 msgid "Subject"
@@ -139,39 +139,6 @@ msgstr "Kolo už skončilo."
 
 msgid "View the solution."
 msgstr "Pozrieť vzorové riešenie."
-
-# Task Statements
-#, python-format
-msgid "%(count)d day"
-msgid_plural "%(count)d days"
-msgstr[0] "%(count)d deň"
-msgstr[1] "%(count)d dni"
-msgstr[2] "%(count)d dňa"
-msgstr[3] "%(count)d dní"
-
-#, python-format
-msgid "%(count)d hour"
-msgid_plural "%(count)d hours"
-msgstr[0] "%(count)d hodina"
-msgstr[1] "%(count)d hodiny"
-msgstr[2] "%(count)d hodiny"
-msgstr[3] "%(count)d hodín"
-
-#, python-format
-msgid "%(count)d minute"
-msgid_plural "%(count)d minutes"
-msgstr[0] "%(count)d minúta"
-msgstr[1] "%(count)d minúty"
-msgstr[2] "%(count)d minúty"
-msgstr[3] "%(count)d minút"
-
-#, python-format
-msgid "%(count)d second"
-msgid_plural "%(count)d seconds"
-msgstr[0] "%(count)d sekunda"
-msgstr[1] "%(count)d sekundy"
-msgstr[2] "%(count)d sekundy"
-msgstr[3] "%(count)d sekúnd"
 
 msgid "authorized groups"
 msgstr "autorizované skupiny"
@@ -647,6 +614,12 @@ msgstr "Upraviť"
 msgid "Task"
 msgstr "Úloha"
 
+msgid "Description points are hidden in results!"
+msgstr "Body za popis sa nezobrazujú vo výsledkovke!"
+
+msgid "You can change this in task settings."
+msgstr "Toto môžeš zmeniť vo vlastnostiach úlohy."
+
 msgid "Download all original solutions"
 msgstr "Stiahnuť všetky pôvodné riešenia"
 
@@ -951,3 +924,36 @@ msgstr ""
 
 msgid "This article was last modified:"
 msgstr "Čas poslednej úpravy:"
+
+# Task Statements
+#, python-format
+msgid "%(count)d day"
+msgid_plural "%(count)d days"
+msgstr[0] "%(count)d deň"
+msgstr[1] "%(count)d dni"
+msgstr[2] "%(count)d dňa"
+msgstr[3] "%(count)d dní"
+
+#, python-format
+msgid "%(count)d hour"
+msgid_plural "%(count)d hours"
+msgstr[0] "%(count)d hodina"
+msgstr[1] "%(count)d hodiny"
+msgstr[2] "%(count)d hodiny"
+msgstr[3] "%(count)d hodín"
+
+#, python-format
+msgid "%(count)d minute"
+msgid_plural "%(count)d minutes"
+msgstr[0] "%(count)d minúta"
+msgstr[1] "%(count)d minúty"
+msgstr[2] "%(count)d minúty"
+msgstr[3] "%(count)d minút"
+
+#, python-format
+msgid "%(count)d second"
+msgid_plural "%(count)d seconds"
+msgstr[0] "%(count)d sekunda"
+msgstr[1] "%(count)d sekundy"
+msgstr[2] "%(count)d sekundy"
+msgstr[3] "%(count)d sekúnd"

--- a/trojsten/reviews/templates/admin/review_form.html
+++ b/trojsten/reviews/templates/admin/review_form.html
@@ -13,6 +13,11 @@
 
 {% block content %}
 <h1>Opravovanie úlohy: {{ task }}</h1>
+
+{% if not task.description_points_visible %}
+<p style="color: red"><b>{% trans 'Description points are hidden in results!' %}</b> {% trans 'You can change this in task settings.' %}</p>
+{% endif %}
+
 <h2>Stiahnuť riešenia</h2>
 <a href="{% url 'admin:download_latest_submits' task.pk %}">
     {% trans 'Download all original solutions' %}

--- a/trojsten/reviews/tests.py
+++ b/trojsten/reviews/tests.py
@@ -16,6 +16,7 @@ from django.test import TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.text import slugify
+from django.utils.translation import ugettext_lazy as _
 
 from trojsten.contests.models import Competition, Round, Semester, Task
 from trojsten.people.models import User
@@ -261,6 +262,21 @@ class ReviewTest(TestCase):
         response = self.client.get(url)
         self.assertNotContains(response, comment)
         self.assertContains(response, multi_line_comment)
+
+    def test_hidden_points_alert(self):
+        self.client.force_login(self.staff)
+        url = reverse(self.url_name, kwargs={"task_pk": self.task.id})
+        self.task.description_points_visible = False
+        self.task.save()
+
+        response = self.client.get(url)
+        self.assertContains(response, _("Description points are hidden in results!"))
+
+        self.task.description_points_visible = True
+        self.task.save()
+
+        response = self.client.get(url)
+        self.assertNotContains(response, _("Description points are hidden in results!"))
 
 
 @override_settings(SUBMIT_PATH=tempfile.mkdtemp(dir=path.join(path.dirname(__file__), "test_data")))


### PR DESCRIPTION
Keď nie je zakliknuté zobrazovanie bodov vo výsledkovke, opravovateľ na to bude upozornený, aby sa nestalo, že to niekto zabudol zapnúť.

![image](https://user-images.githubusercontent.com/11409143/83971099-ac482400-a8d9-11ea-84fb-af7ec80383ab.png)
