### PR TITLE
Remove UFO link from Prask

### DIFF
--- a/trojsten/settings/prask.py
+++ b/trojsten/settings/prask.py
@@ -1,6 +1,6 @@
 from trojsten.settings.production import *
 
 SITE_ID = 2
-NAVBAR_SITES = [1, 7, 5]
+NAVBAR_SITES = [1, 5]
 
 SUBMIT_DESCRIPTION_ALLOWED_EXTENSIONS += [".ods", ".xls", ".xlsx"]


### PR DESCRIPTION
If I understood correctly, this should remove `UFO` link in prask page
![image](https://user-images.githubusercontent.com/22679154/97333420-d9db3d00-187b-11eb-8afa-dc2ebcdbcce7.png)
