### PR TITLE
Change ES6 imports to CommonJS to fix import errors

### DIFF
--- a/trojsten/special/plugin_prask_8_1_1/checker.js
+++ b/trojsten/special/plugin_prask_8_1_1/checker.js
@@ -1,6 +1,6 @@
-import { ZergInterpreter } from "./static/plugin_prask_8_1_1/components/interpreter.mjs";
-import { Program } from "./static/plugin_prask_8_1_1/components/parser.mjs";
-import { readFileSync } from 'fs';
+const ZergInterpreter = require('./static/plugin_prask_8_1_1/components/interpreter.js');
+const Program = require('./static/plugin_prask_8_1_1/components/parser.js');
+const readFileSync = require('fs').readFileSync;
 
 function nop() {}
 

--- a/trojsten/special/plugin_prask_8_1_1/static/plugin_prask_8_1_1/components/controllers.js
+++ b/trojsten/special/plugin_prask_8_1_1/static/plugin_prask_8_1_1/components/controllers.js
@@ -1,8 +1,5 @@
 'use strict';
 
-import { ZergInterpreter } from "./interpreter.mjs"
-import { Program } from "./parser.mjs"
-
 angular.module('zerg.controllers', [])
     .controller('SeriesCtrl', ['$rootScope', '$scope', 'Levels',
         function ($rootScope, $scope, Levels) {

--- a/trojsten/special/plugin_prask_8_1_1/static/plugin_prask_8_1_1/components/interpreter.js
+++ b/trojsten/special/plugin_prask_8_1_1/static/plugin_prask_8_1_1/components/interpreter.js
@@ -1,4 +1,4 @@
-export var ZergInterpreter = function(program, level, walkToCallback, rotateRightCallback, rotateLeftCallback, redrawCallback, highlightLineCallback, updateBatteryCallback) {
+var ZergInterpreter = function(program, level, walkToCallback, rotateRightCallback, rotateLeftCallback, redrawCallback, highlightLineCallback, updateBatteryCallback) {
 	this.program = program;
 	this.level = level;
 	this.walkToCallback = walkToCallback;
@@ -295,3 +295,5 @@ ZergInterpreter.prototype = {
 	}
 
 }
+
+module.exports = ZergInterpreter

--- a/trojsten/special/plugin_prask_8_1_1/static/plugin_prask_8_1_1/components/parser.js
+++ b/trojsten/special/plugin_prask_8_1_1/static/plugin_prask_8_1_1/components/parser.js
@@ -1,4 +1,4 @@
-export var Program = function(program) {
+var Program = function(program) {
 
     this.subroutines = {};
     this.errors = [];
@@ -275,3 +275,5 @@ Program.prototype = {
     LOGIC_PAR_LEFT:         26,
     LOGIC_PAR_RIGHT:        27
 };
+
+module.exports = Program

--- a/trojsten/special/plugin_prask_8_1_1/templates/plugin_prask_8_1_1/index.html
+++ b/trojsten/special/plugin_prask_8_1_1/templates/plugin_prask_8_1_1/index.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="{% static 'plugin_prask_8_1_1/css/app.css' %}">
 
     <script>
+      var module = {};  // A hack to make CommonJS (CJS) modules "work" in the browser.
       var STATIC_URL_PREFIX = '{{ STATIC_URL }}plugin_prask_8_1_1/';
       var DYNAMIC_URL_PREFIX = '{% url "plugin_zergbot:root" %}';
     </script>
@@ -44,10 +45,10 @@
     <!--js-release-minimize-->
     <!-- Using ES6 modules. It has 94% global support at the time of writing (2021-11-22) according to caniuse.com. -->
     <script src="{% static 'plugin_prask_8_1_1/app.js' %}"></script>
-    <script type="module" src="{% static 'plugin_prask_8_1_1/components/controllers.js' %}"></script>
+    <script src="{% static 'plugin_prask_8_1_1/components/controllers.js' %}"></script>
     <script src="{% static 'plugin_prask_8_1_1/components/services.js' %}"></script>
-    <script type="module" src="{% static 'plugin_prask_8_1_1/components/parser.mjs' %}"></script>
-    <script type="module" src="{% static 'plugin_prask_8_1_1/components/interpreter.mjs' %}"></script>
+    <script src="{% static 'plugin_prask_8_1_1/components/parser.js' %}"></script>
+    <script src="{% static 'plugin_prask_8_1_1/components/interpreter.js' %}"></script>
     <script src="{% static 'plugin_prask_8_1_1/components/phaser-game/Boot.js' %}"></script>
     <script src="{% static 'plugin_prask_8_1_1/components/phaser-game/Preload.js' %}"></script>
     <script src="{% static 'plugin_prask_8_1_1/components/phaser-game/Game.js' %}"></script>

--- a/trojsten/special/plugin_prask_8_1_1/views.py
+++ b/trojsten/special/plugin_prask_8_1_1/views.py
@@ -140,7 +140,7 @@ def is_serie_rated(serie):
 def run_interpreter(user, sid, lid, programRaw, level_data):
     try:
         completion = subprocess.run(
-            ["node", "--experimental-modules", os.path.join(FILE_DIR, "checker.mjs")],
+            ["node", os.path.join(FILE_DIR, "checker.js")],
             input=json.dumps({"programRaw": programRaw, "level": level_data}),
             text=True,
             timeout=1,


### PR DESCRIPTION
I used ES6 imports for client-side JS. Django suffixes static files with some magic, probably for rolling out updates without having to deal with user-cache pruning. Django then needs to find occurrences of the given file in other sources and also adds the suffix there.

However, Django was not adding the suffixes for imports in `components/controllers.js`. Now the reason might be that I mistakenly used `.js` instead of `.mjs` for an ES6 module file. But I don't have access to the production server to test this so I just changed it to CommonJS modules with a small hack of defining a global `module` variable to silence client-side errors. This is because CommonJS modules don't have a native browser support. 