### PR TITLE
Whitelist static files from static.ksp.sk for Angular in Zergbot

### DIFF
--- a/trojsten/special/plugin_prask_8_1_1/static/plugin_prask_8_1_1/app.js
+++ b/trojsten/special/plugin_prask_8_1_1/static/plugin_prask_8_1_1/app.js
@@ -8,7 +8,14 @@ angular.module('zerg', [
     'zerg.controllers',
     'zerg.services'
 ])
-    .config(['$routeProvider', function ($routeProvider) {
+    
+    .config(['$routeProvider', '$sceDelegateProvider', function ($routeProvider, $sceDelegateProvider) {
+
+        $sceDelegateProvider.resourceUrlWhitelist([
+            // Allow same origin resource loads.
+            'self',
+            'https://static.ksp.sk/**'
+        ]);
 
         $routeProvider.when('/series', {
             templateUrl: STATIC_URL_PREFIX + 'partials/series.html',


### PR DESCRIPTION
AngularJS has a way of whitelisting resource locations. "Same origin" is whitelisted by default so on beta.ksp.sk everything worked, but in prod we're serving statics from static.ksp.sk. Therefore, it needs to be whitelisted for Angular.