### PR TITLE
Math scrollbar

### DIFF
--- a/css/src/base.less
+++ b/css/src/base.less
@@ -470,6 +470,10 @@ footer {
   padding-top: (@navbar-height + 10px);
 }
 
+.MathJax_Display {
+  overflow-y: hidden; /*creates x-scroll for display math when necessary*/
+}
+
 table.floatThead-table {
   border-top: none;
   border-bottom: none;

--- a/css/src/base.less
+++ b/css/src/base.less
@@ -470,10 +470,6 @@ footer {
   padding-top: (@navbar-height + 10px);
 }
 
-.MathJax_Display {
-  overflow-y: hidden; /*creates x-scroll for display math when necessary*/
-}
-
 table.floatThead-table {
   border-top: none;
   border-bottom: none;


### PR DESCRIPTION
Matické výrazy v prípade, že sú veľké, pretekajú obrazovku, čo je problém pri dlhších výrazoch, resp. na mobile. Toto by to malo vyriešiť tým, že v prípade potreby sa tam pridá horizontálny scrollbar. Rieši issue #1400.