### PR TITLE
Fixed issue - poetry download site changed

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -5,14 +5,14 @@ ENV PYTHONUNBUFFERED=0 \
 
 RUN apk add --no-cache curl
 
-RUN curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python \
-    && ln -s /root/.poetry/bin/poetry /usr/local/bin/poetry
-
 COPY ./docker/common/ /tmp/build/
 
 RUN set -x \
     && sh /tmp/build/install_build_deps.sh \
     && sh /tmp/build/install_runtime_deps.sh
+    
+RUN curl -sSL https://install.python-poetry.org | python - \
+    && ln -s /root/.local/bin/poetry /usr/local/bin/poetry
 
 COPY ./fonts/* /usr/share/fonts/
 

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -6,8 +6,8 @@ RUN apk add --no-cache --virtual common-deps curl
 
 FROM base AS builder
 
-RUN curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python \
-    && ln -s /root/.poetry/bin/poetry /usr/local/bin/poetry
+RUN curl -sSL https://install.python-poetry.org | python - \
+    && ln -s /root/.local/bin/poetry /usr/local/bin/poetry
 
 COPY ./pyproject.toml /tmp/build/
 COPY ./poetry.lock /tmp/build/


### PR DESCRIPTION
Fixed issue with poetry download during `docker-compose build` phase (download site migrated to https://install.python-poetry.org.