### PR TITLE
Show points in the results after decreasing according to the user's coefficient

### DIFF
--- a/trojsten/rules/kms.py
+++ b/trojsten/rules/kms.py
@@ -221,6 +221,16 @@ class KMSResultsGenerator(CategoryTagKeyGeneratorMixin, ResultsGenerator):
             if cell.active
         )
 
+    def format_row_cells(self, res_request, row, cols):
+        coefficient = self.get_user_coefficient(row.user, res_request.round)
+        for key, cell in row.cells_by_key.items():
+            points = self.get_cell_total(res_request, cell)
+            cell.full_points = points
+            cell.manual_points = self.get_cell_points_for_row_total(
+                res_request, cell, key, coefficient
+            )
+            super(KMSResultsGenerator, self).format_row_cell(res_request, cell)
+
     def add_special_row_cells(self, res_request, row, cols):
         super(KMSResultsGenerator, self).add_special_row_cells(res_request, row, cols)
         coefficient = self.get_user_coefficient(row.user, res_request.round)

--- a/trojsten/rules/test.py
+++ b/trojsten/rules/test.py
@@ -636,6 +636,21 @@ class KMSRulesTest(TestCase):
         row_alfa = get_row_for_user(scoreboard, user)
         self.assertEqual(row_alfa.cell_list[col_to_index_map["sum"]].points, "35")
 
+    def test_show_decreased_points(self):
+        points = [0, 7, 3]
+        user = self._create_user_with_coefficient(1, use_kms_camp=True)
+        self._create_submits(user, points)
+        response = self.client.get("%s?single_round=True" % self.url)
+        self.assertEqual(response.status_code, 200)
+        scoreboard = get_scoreboard(response.context["scoreboards"], KMS_ALFA)
+        col_to_index_map = get_col_to_index_map(scoreboard)
+        row_alfa = get_row_for_user(scoreboard, user)
+        self.assertEqual(row_alfa.cell_list[col_to_index_map["sum"]].points, "8")
+        self.assertEqual(row_alfa.cell_list[col_to_index_map[2]].points, "5")
+        self.assertEqual(row_alfa.cell_list[col_to_index_map[3]].points, "3")
+        self.assertContains(response, "hodnotenie: 7")
+        self.assertNotContains(response, "hodnotenie: 5")
+
 
 class KSPRulesOneUserTest(TestCase):
     def setUp(self):


### PR DESCRIPTION
KMS: If someone has 7 points but the task is only for 2/3 for him due to the coefficient, it will show up as 5 points and 7 will be in the tooltip