### PR TITLE
Fix Susi rules and KMS leaderboard

### DIFF
--- a/trojsten/results/manager.py
+++ b/trojsten/results/manager.py
@@ -48,7 +48,7 @@ def get_results_tags_for_rounds(rounds):
     """
     # FIXME(generic_results_stage_2): frozen results
     # @FUTURE firstly try to get tags from frozen results and then calculate the rest
-    return (r.semester.competition.rules.get_results_tags() for r in rounds)
+    return (r.semester.competition.rules.get_results_tags(r.semester.year) for r in rounds)
 
 
 def _generate_raw_results(tag_key, round, single_round):

--- a/trojsten/results/templates/trojsten/results/explain_susi_xp.html
+++ b/trojsten/results/templates/trojsten/results/explain_susi_xp.html
@@ -1,0 +1,17 @@
+{% extends "trojsten/layout/main.html" %}
+
+{% block title %}Moje body skúsenosti v Suši{% endblock %}
+
+{% block page_header %}
+<h1>Moje body skúsenosti v Suši</h1>
+{% endblock %}
+
+{% block page_content %}
+<h3>Úspešné časti</h3>
+<ul>
+{% for semester, category in semesters %}
+<li>Časť {{ semester }}, kategória {{ category }} </li>
+{% endfor %}
+</ul>
+
+{% endblock %}

--- a/trojsten/results/urls.py
+++ b/trojsten/results/urls.py
@@ -6,4 +6,5 @@ urlpatterns = [
     url(r"^(?P<round_id>(\d+))/$", views.view_results, name="view_results"),
     url(r"^(?P<round_id>(\d+))/(?P<tag_key>(.+))/$", views.view_results, name="view_results"),
     url(r"^$", views.view_latest_results, name="view_latest_results"),
+    url(r"^susiXP/(?P<round_id>(\d+))/$", views.explain_susi_xp, name="explain_susi_xp"),
 ]

--- a/trojsten/results/views.py
+++ b/trojsten/results/views.py
@@ -36,7 +36,7 @@ def view_results(request, round_id, tag_key=DEFAULT_TAG_KEY):
 @login_required
 def explain_susi_xp(request, round_id):
     generator = SUSIResultsGenerator(susi_constants.SUSI_AGAT)
-    generator.prepare_coefficients(Round.objects.get(id=round_id))
+    generator.prepare_coefficients(get_object_or_404(Round, pk=round_id))
     return render(
         request,
         "trojsten/results/explain_susi_xp.html",

--- a/trojsten/results/views.py
+++ b/trojsten/results/views.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
+from django.contrib.auth.decorators import login_required
 from django.shortcuts import get_object_or_404, render
 
 from trojsten.contests.models import Competition, Round
+from trojsten.rules import susi_constants
+from trojsten.rules.susi import SUSIResultsGenerator
 from trojsten.utils.utils import is_true
 
 from .constants import DEFAULT_TAG_KEY
@@ -28,6 +31,17 @@ def view_results(request, round_id, tag_key=DEFAULT_TAG_KEY):
         "susi_is_discovery": round.susi_is_discovery,
     }
     return render(request, "trojsten/results/view_results.html", context)
+
+
+@login_required
+def explain_susi_xp(request, round_id):
+    generator = SUSIResultsGenerator(susi_constants.SUSI_AGAT)
+    generator.prepare_coefficients(Round.objects.get(id=round_id))
+    return render(
+        request,
+        "trojsten/results/explain_susi_xp.html",
+        {"semesters": generator.which_semesters.get(request.user.id, [])},
+    )
 
 
 def view_latest_results(request):

--- a/trojsten/rules/default.py
+++ b/trojsten/rules/default.py
@@ -22,7 +22,7 @@ class CompetitionRules(object):
             testing_status=submit_constants.SUBMIT_STATUS_REVIEWED
         )
 
-    def get_results_tags(self):
+    def get_results_tags(self, year=None):
         return (self.RESULTS_TAGS[tag_key] for tag_key in self.RESULTS_TAGS)
 
     def get_results_generator(self, tag_key):

--- a/trojsten/rules/kms.py
+++ b/trojsten/rules/kms.py
@@ -8,7 +8,7 @@ from django.db.models import Count, Q
 
 from trojsten.contests.models import Semester
 from trojsten.events.models import EventParticipant
-from trojsten.results.constants import COEFFICIENT_COLUMN_KEY
+from trojsten.results.constants import COEFFICIENT_COLUMN_KEY, UNKNOWN_POINTS_SYMBOL
 from trojsten.results.generator import CategoryTagKeyGeneratorMixin, ResultsGenerator
 from trojsten.results.helpers import get_total_score_column_index
 from trojsten.results.manager import get_results, get_results_tags_for_rounds
@@ -224,11 +224,11 @@ class KMSResultsGenerator(CategoryTagKeyGeneratorMixin, ResultsGenerator):
     def format_row_cells(self, res_request, row, cols):
         coefficient = self.get_user_coefficient(row.user, res_request.round)
         for key, cell in row.cells_by_key.items():
-            points = self.get_cell_total(res_request, cell)
-            cell.full_points = points
-            cell.manual_points = self.get_cell_points_for_row_total(
-                res_request, cell, key, coefficient
-            )
+            cell.full_points = cell.manual_points
+            if cell.manual_points not in [None, UNKNOWN_POINTS_SYMBOL]:
+                cell.manual_points = self.get_cell_points_for_row_total(
+                    res_request, cell, key, coefficient
+                )
             super(KMSResultsGenerator, self).format_row_cell(res_request, cell)
 
     def add_special_row_cells(self, res_request, row, cols):

--- a/trojsten/rules/susi.py
+++ b/trojsten/rules/susi.py
@@ -143,7 +143,7 @@ class SUSIResultsGenerator(CategoryTagKeyGeneratorMixin, ResultsGenerator):
                             self.which_semesters.setdefault(user_id, []).append(
                                 (semester, category)
                             )
-                        last_points = cur_points
+                            last_points = cur_points
 
     def get_minimal_year_of_graduation(self, res_request, user):
         return -1

--- a/trojsten/rules/susi.py
+++ b/trojsten/rules/susi.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from unidecode import unidecode
 
 import trojsten.rules.susi_constants as constants
-from trojsten.contests.models import Round, Semester, Task
+from trojsten.contests.models import Round, Semester
 from trojsten.events.models import EventParticipant
 from trojsten.results.constants import (
     COEFFICIENT_COLUMN_KEY,
@@ -42,14 +42,9 @@ class SUSIResultsGenerator(CategoryTagKeyGeneratorMixin, ResultsGenerator):
         self.coefficients = {}
 
     def get_results_level(self):
+        if self.tag.key not in constants.HIGH_SCHOOL_CATEGORIES:
+            return 0
         return constants.HIGH_SCHOOL_CATEGORIES.index(self.tag.key) + 1
-
-    def get_task_queryset(self, res_request):
-        """In Xth category results table, there are results for tasks X-8."""
-        tasks = Task.objects.filter(round=res_request.round).order_by("number")
-        if self.tag.key != constants.SUSI_OPEN:
-            tasks = tasks.filter(number__gte=self.get_results_level())
-        return tasks
 
     def get_user_coefficient(self, user, round):
         if user not in self.coefficients:
@@ -199,6 +194,9 @@ class SUSIResultsGenerator(CategoryTagKeyGeneratorMixin, ResultsGenerator):
 class SUSIRules(CompetitionRules):
     RESULTS_TAGS = {
         constants.SUSI_OPEN: ResultsTag(key=constants.SUSI_OPEN, name=constants.SUSI_OPEN),
+        constants.SUSI_OLD_CIFERSKY_CECH: ResultsTag(
+            key=constants.SUSI_OLD_CIFERSKY_CECH, name=constants.SUSI_OLD_CIFERSKY_CECH
+        ),
         constants.SUSI_AGAT: ResultsTag(key=constants.SUSI_AGAT, name=constants.SUSI_AGAT),
         constants.SUSI_BLYSKAVICA: ResultsTag(
             key=constants.SUSI_BLYSKAVICA, name=constants.SUSI_BLYSKAVICA
@@ -212,6 +210,23 @@ class SUSIRules(CompetitionRules):
     }
 
     RESULTS_GENERATOR_CLASS = SUSIResultsGenerator
+
+    def get_results_tags(self, year=None):
+        if year is not None and year < constants.YEAR_SINCE_FOUR_CATEGORIES:
+            tags = [
+                constants.SUSI_OLD_CIFERSKY_CECH,
+                constants.SUSI_AGAT,
+                constants.SUSI_BLYSKAVICA,
+            ]
+        else:
+            tags = [
+                constants.SUSI_OPEN,
+                constants.SUSI_AGAT,
+                constants.SUSI_BLYSKAVICA,
+                constants.SUSI_CVALAJUCI,
+                constants.SUSI_DIALNICA,
+            ]
+        return (self.RESULTS_TAGS[tag_key] for tag_key in tags)
 
     def get_actual_result_rounds(self, competition):
         active_rounds = Round.objects.filter(

--- a/trojsten/rules/susi_constants.py
+++ b/trojsten/rules/susi_constants.py
@@ -5,8 +5,11 @@ SUSI_CVALAJUCI = "Cválajúci"
 SUSI_DIALNICA = "Diaľnica"
 HIGH_SCHOOL_CATEGORIES = [SUSI_AGAT, SUSI_BLYSKAVICA, SUSI_CVALAJUCI, SUSI_DIALNICA]
 SUSI_OPEN = "Zásielkovňa"
+SUSI_OLD_CIFERSKY_CECH = "Cíferský-cech"
 SUSI_CAMP_TYPE = "Suši sústredenie"
 
+# The year of the competition since which there are 4 high school categories instead of only 2
+YEAR_SINCE_FOUR_CATEGORIES = 5
 
 SUSI_COMPETITION_ID = 9  # The ID (pk) of Susi competition in the database.
 

--- a/trojsten/rules/test.py
+++ b/trojsten/rules/test.py
@@ -210,9 +210,9 @@ class KMSCoefficientTest(TestCase):
                 submit = Submit.objects.create(
                     task=task,
                     user=user,
-                    submit_type=1,
+                    submit_type=submit_constants.SUBMIT_TYPE_DESCRIPTION,
                     points=point,
-                    testing_status="reviewed",
+                    testing_status=submit_constants.SUBMIT_STATUS_REVIEWED,
                 )
                 submit.time = self.end + timezone.timedelta(-1)
                 submit.save()
@@ -486,9 +486,9 @@ class KMSRulesTest(TestCase):
                 submit = Submit.objects.create(
                     task=self.tasks[i],
                     user=user,
-                    submit_type=1,
+                    submit_type=submit_constants.SUBMIT_TYPE_DESCRIPTION,
                     points=points[i],
-                    testing_status="reviewed",
+                    testing_status=submit_constants.SUBMIT_STATUS_REVIEWED,
                 )
                 submit.time = self.end + timezone.timedelta(-1)
                 submit.save()

--- a/trojsten/rules/test.py
+++ b/trojsten/rules/test.py
@@ -1304,6 +1304,7 @@ class SusiCoefficientTest(TestCase):
                 self.assertEqual(row.active, category == active_category)
                 self.assertEqual(get_row_total(row, col_to_index_map), points)
                 self.assertEqual(get_coefficient(row, col_to_index_map), coefficient)
+                count += 1
             self.assertEqual(count, len(self.users))
             row = get_row_for_user(scoreboard, self.old_user)
             self.assertEqual(row.active, False)

--- a/trojsten/rules/test.py
+++ b/trojsten/rules/test.py
@@ -650,6 +650,16 @@ class KMSRulesTest(TestCase):
         points = [0, 7, 3]
         user = self._create_user_with_coefficient(1, use_kms_camp=True)
         self._create_submits(user, points)
+        submit = Submit.objects.create(
+            task=self.tasks[3],
+            user=user,
+            submit_type=submit_constants.SUBMIT_TYPE_DESCRIPTION,
+            points=0,
+            testing_status=submit_constants.SUBMIT_STATUS_IN_QUEUE,
+        )
+        submit.time = self.end + timezone.timedelta(-1)
+        submit.save()
+
         response = self.client.get("%s?single_round=True" % self.url)
         self.assertEqual(response.status_code, 200)
         scoreboard = get_scoreboard(response.context["scoreboards"], KMS_ALFA)
@@ -658,6 +668,12 @@ class KMSRulesTest(TestCase):
         self.assertEqual(row_alfa.cell_list[col_to_index_map["sum"]].points, "8")
         self.assertEqual(row_alfa.cell_list[col_to_index_map[2]].points, "5")
         self.assertEqual(row_alfa.cell_list[col_to_index_map[3]].points, "3")
+        self.assertEqual(row_alfa.cell_list[col_to_index_map[4]].points, "?")
+        self.assertEqual(row_alfa.cell_list[col_to_index_map[5]].points, "")
+
+        submit.time = self.end + timezone.timedelta(-1)
+        submit.save()
+
         self.assertContains(response, "hodnotenie: 7")
         self.assertNotContains(response, "hodnotenie: 5")
 


### PR DESCRIPTION
fix showing empty and not yet reviewed tasks showing as 0 points in KMS leaderboard

enable showing old categories for old rounds

do not hardcode task-to-category assignment, it will be determined by the categories assigned to tasks in the DB - fix for Objavné kolo